### PR TITLE
Task/fix url image upload

### DIFF
--- a/example/vision/main.go
+++ b/example/vision/main.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	testImageURL  = "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg"
-	testImageURL2 = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+	testImageURL = "https://static0.srcdn.com/wordpress/wp-content/uploads/2020/04/Rickroll-Wide.jpg"
 )
 
 func main() {
@@ -45,7 +44,7 @@ func anthropicExample(ctx context.Context) {
 	fmt.Println(response.Content)
 
 	base64Message := message.NewUserMessage("What do you see in this image?")
-	imageData, mimeType, err := downloadImage(testImageURL2)
+	imageData, mimeType, err := downloadImage(testImageURL)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -79,7 +78,7 @@ func openaiExample(ctx context.Context) {
 	fmt.Println(response.Content)
 
 	base64Message := message.NewUserMessage("Analyze this image and tell me what you observe.")
-	imageData, mimeType, err := downloadImage(testImageURL2)
+	imageData, mimeType, err := downloadImage(testImageURL)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -130,7 +129,7 @@ func multiModalExample(ctx context.Context) {
 	multiMessage := message.NewUserMessage("Compare these two images and tell me the differences:")
 	multiMessage.AddImageURL(testImageURL, "")
 
-	imageData, mimeType, err := downloadImage(testImageURL2)
+	imageData, mimeType, err := downloadImage("https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/vision/main.go
+++ b/example/vision/main.go
@@ -18,12 +18,10 @@ const (
 
 func main() {
 	ctx := context.Background()
-	anthropicExample(ctx)
-	openaiExample(ctx)
-	multiModalExample(ctx)
+	visionExample(ctx)
 }
 
-func anthropicExample(ctx context.Context) {
+func visionExample(ctx context.Context) {
 	client, err := llm.NewLLM(
 		model.ProviderAnthropic,
 		llm.WithAPIKey(""),
@@ -34,7 +32,7 @@ func anthropicExample(ctx context.Context) {
 		log.Fatal(err)
 	}
 
-	urlMessage := message.NewUserMessage("Describe this image in detail.")
+	urlMessage := message.NewUserMessage("What do you see in this image? Explain it like grug would.")
 	urlMessage.AddImageURL(testImageURL, "")
 
 	response, err := client.SendMessages(ctx, []message.Message{urlMessage}, nil)
@@ -44,40 +42,6 @@ func anthropicExample(ctx context.Context) {
 	fmt.Println(response.Content)
 
 	base64Message := message.NewUserMessage("What do you see in this image?")
-	imageData, mimeType, err := downloadImage(testImageURL)
-	if err != nil {
-		log.Fatal(err)
-	}
-	base64Message.AddBinary(mimeType, imageData)
-
-	response, err = client.SendMessages(ctx, []message.Message{base64Message}, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(response.Content)
-}
-
-func openaiExample(ctx context.Context) {
-	client, err := llm.NewLLM(
-		model.ProviderOpenAI,
-		llm.WithAPIKey(""),
-		llm.WithModel(model.OpenAIModels[model.GPT4o]),
-		llm.WithMaxTokens(1000),
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	urlMessage := message.NewUserMessage("What is in this image?")
-	urlMessage.AddImageURL(testImageURL, "high")
-
-	response, err := client.SendMessages(ctx, []message.Message{urlMessage}, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(response.Content)
-
-	base64Message := message.NewUserMessage("Analyze this image and tell me what you observe.")
 	imageData, mimeType, err := downloadImage(testImageURL)
 	if err != nil {
 		log.Fatal(err)
@@ -113,31 +77,4 @@ func downloadImage(url string) ([]byte, string, error) {
 	}
 
 	return data, mimeType, nil
-}
-
-func multiModalExample(ctx context.Context) {
-	client, err := llm.NewLLM(
-		model.ProviderAnthropic,
-		llm.WithAPIKey(""),
-		llm.WithModel(model.AnthropicModels[model.Claude35Sonnet]),
-		llm.WithMaxTokens(1500),
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	multiMessage := message.NewUserMessage("Compare these two images and tell me the differences:")
-	multiMessage.AddImageURL(testImageURL, "")
-
-	imageData, mimeType, err := downloadImage("https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg")
-	if err != nil {
-		log.Fatal(err)
-	}
-	multiMessage.AddBinary(mimeType, imageData)
-
-	response, err := client.SendMessages(ctx, []message.Message{multiMessage}, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(response.Content)
 }

--- a/example/vision/main.go
+++ b/example/vision/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	llm "github.com/joakimcarlsson/ai/providers"
+)
+
+const (
+	testImageURL  = "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg"
+	testImageURL2 = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+)
+
+func main() {
+	ctx := context.Background()
+	anthropicExample(ctx)
+	openaiExample(ctx)
+	multiModalExample(ctx)
+}
+
+func anthropicExample(ctx context.Context) {
+	client, err := llm.NewLLM(
+		model.ProviderAnthropic,
+		llm.WithAPIKey(""),
+		llm.WithModel(model.AnthropicModels[model.Claude35Sonnet]),
+		llm.WithMaxTokens(1000),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	urlMessage := message.NewUserMessage("Describe this image in detail.")
+	urlMessage.AddImageURL(testImageURL, "")
+
+	response, err := client.SendMessages(ctx, []message.Message{urlMessage}, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(response.Content)
+
+	base64Message := message.NewUserMessage("What do you see in this image?")
+	imageData, mimeType, err := downloadImage(testImageURL2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	base64Message.AddBinary(mimeType, imageData)
+
+	response, err = client.SendMessages(ctx, []message.Message{base64Message}, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(response.Content)
+}
+
+func openaiExample(ctx context.Context) {
+	client, err := llm.NewLLM(
+		model.ProviderOpenAI,
+		llm.WithAPIKey(""),
+		llm.WithModel(model.OpenAIModels[model.GPT4o]),
+		llm.WithMaxTokens(1000),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	urlMessage := message.NewUserMessage("What is in this image?")
+	urlMessage.AddImageURL(testImageURL, "high")
+
+	response, err := client.SendMessages(ctx, []message.Message{urlMessage}, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(response.Content)
+
+	base64Message := message.NewUserMessage("Analyze this image and tell me what you observe.")
+	imageData, mimeType, err := downloadImage(testImageURL2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	base64Message.AddBinary(mimeType, imageData)
+
+	response, err = client.SendMessages(ctx, []message.Message{base64Message}, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(response.Content)
+}
+
+func downloadImage(url string) ([]byte, string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to download image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("failed to download image: status %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read image data: %w", err)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return data, mimeType, nil
+}
+
+func multiModalExample(ctx context.Context) {
+	client, err := llm.NewLLM(
+		model.ProviderAnthropic,
+		llm.WithAPIKey(""),
+		llm.WithModel(model.AnthropicModels[model.Claude35Sonnet]),
+		llm.WithMaxTokens(1500),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	multiMessage := message.NewUserMessage("Compare these two images and tell me the differences:")
+	multiMessage.AddImageURL(testImageURL, "")
+
+	imageData, mimeType, err := downloadImage(testImageURL2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	multiMessage.AddBinary(mimeType, imageData)
+
+	response, err := client.SendMessages(ctx, []message.Message{multiMessage}, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(response.Content)
+}

--- a/message/base.go
+++ b/message/base.go
@@ -146,6 +146,17 @@ func (m *Message) BinaryContent() []BinaryContent {
 	return binaryContents
 }
 
+// ImageURLContent returns all image URL content parts from the message
+func (m *Message) ImageURLContent() []ImageURLContent {
+	imageURLContents := make([]ImageURLContent, 0)
+	for _, part := range m.Parts {
+		if c, ok := part.(ImageURLContent); ok {
+			imageURLContents = append(imageURLContents, c)
+		}
+	}
+	return imageURLContents
+}
+
 // ToolCalls returns all tool call parts from the message
 func (m *Message) ToolCalls() []ToolCall {
 	var toolCalls []ToolCall

--- a/providers/anthropic.go
+++ b/providers/anthropic.go
@@ -74,11 +74,21 @@ func (a *anthropicClient) convertMessages(messages []message.Message) (anthropic
 			}
 			var contentBlocks []anthropic.ContentBlockParamUnion
 			contentBlocks = append(contentBlocks, content)
+
 			for _, binaryContent := range msg.BinaryContent() {
 				base64Image := binaryContent.String(model.ProviderAnthropic)
 				imageBlock := anthropic.NewImageBlockBase64(binaryContent.MIMEType, base64Image)
 				contentBlocks = append(contentBlocks, imageBlock)
 			}
+
+			for _, imageURLContent := range msg.ImageURLContent() {
+				imageBlock := anthropic.NewImageBlock(anthropic.URLImageSourceParam{
+					Type: "url",
+					URL:  imageURLContent.URL,
+				})
+				contentBlocks = append(contentBlocks, imageBlock)
+			}
+
 			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(contentBlocks...))
 
 		case message.Assistant:

--- a/providers/openai.go
+++ b/providers/openai.go
@@ -75,10 +75,19 @@ func (o *openaiClient) convertMessages(messages []message.Message) (openaiMessag
 			var content []openai.ChatCompletionContentPartUnionParam
 			textBlock := openai.ChatCompletionContentPartTextParam{Text: msg.Content().String()}
 			content = append(content, openai.ChatCompletionContentPartUnionParam{OfText: &textBlock})
+
 			for _, binaryContent := range msg.BinaryContent() {
 				imageURL := openai.ChatCompletionContentPartImageImageURLParam{URL: binaryContent.String(model.ProviderOpenAI)}
 				imageBlock := openai.ChatCompletionContentPartImageParam{ImageURL: imageURL}
+				content = append(content, openai.ChatCompletionContentPartUnionParam{OfImageURL: &imageBlock})
+			}
 
+			for _, imageURLContent := range msg.ImageURLContent() {
+				imageURL := openai.ChatCompletionContentPartImageImageURLParam{URL: imageURLContent.URL}
+				if imageURLContent.Detail != "" {
+					imageURL.Detail = imageURLContent.Detail
+				}
+				imageBlock := openai.ChatCompletionContentPartImageParam{ImageURL: imageURL}
 				content = append(content, openai.ChatCompletionContentPartUnionParam{OfImageURL: &imageBlock})
 			}
 


### PR DESCRIPTION
This pull request adds support for sending image URLs as part of user messages, in addition to existing binary image support. It introduces a new method for extracting image URL content from messages and updates both the Anthropic and OpenAI providers to handle image URLs correctly. An example demonstrating the new functionality is also added.

**Support for image URLs in messages:**

* Added a new method `ImageURLContent()` to the `Message` struct in `message/base.go` to extract all image URL content parts from a message.
* Updated the Anthropic provider (`providers/anthropic.go`) to include image URL content as image blocks when converting messages.
* Updated the OpenAI provider (`providers/openai.go`) to include image URL content as image blocks, supporting optional detail fields.

**Example usage:**

* Added a new example in `example/vision/main.go` demonstrating how to send both image URLs and binary image data in user messages, and how to download and attach images.