### PR TITLE
Add support for Streamable HTTP in MCP client pool

### DIFF
--- a/tool/mcp-pool.go
+++ b/tool/mcp-pool.go
@@ -84,6 +84,19 @@ func (p *mcpClientPool) getClient(
 			Endpoint:   config.URL,
 			HTTPClient: httpClient,
 		}
+	case MCPStreamableHTTP:
+		httpClient := &http.Client{}
+		if len(config.Headers) > 0 {
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			httpClient.Transport = &headerTransport{
+				base:    transport,
+				headers: config.Headers,
+			}
+		}
+		transport = &mcp.StreamableClientTransport{
+			Endpoint:   config.URL,
+			HTTPClient: httpClient,
+		}
 	default:
 		return nil, fmt.Errorf("invalid MCP type: %s", config.Type)
 	}

--- a/tool/mcp-tools.go
+++ b/tool/mcp-tools.go
@@ -11,8 +11,9 @@ import (
 type MCPType string
 
 const (
-	MCPStdio MCPType = "stdio"
-	MCPSse   MCPType = "sse"
+	MCPStdio          MCPType = "stdio"
+	MCPSse            MCPType = "sse"
+	MCPStreamableHTTP MCPType = "streamable_http"
 )
 
 type mcpTool struct {


### PR DESCRIPTION
- Introduced MCPStreamableHTTP type in mcp-tools.go to handle streamable HTTP connections.
- Enhanced getClient method in mcp-pool.go to configure HTTP clients with custom headers for streamable connections.