### PR TITLE
Add support for custom OpenAI base URL in client configuration

### DIFF
--- a/transcription/openai.go
+++ b/transcription/openai.go
@@ -50,6 +50,13 @@ func newOpenAIClient(opts transcriptionClientOptions) OpenAIClient {
 		)
 	}
 
+	if openaiOpts.baseURL != "" {
+		openaiClientOptions = append(
+			openaiClientOptions,
+			option.WithBaseURL(openaiOpts.baseURL),
+		)
+	}
+
 	client := openai.NewClient(openaiClientOptions...)
 	return &openaiClient{
 		providerOptions: opts,

--- a/transcription/transcription.go
+++ b/transcription/transcription.go
@@ -270,4 +270,11 @@ func WithFilename(filename string) TranscriptionOption {
 type OpenAIOption func(*openaiOptions)
 
 type openaiOptions struct {
+	baseURL string
+}
+
+func WithOpenAIBaseURL(baseURL string) OpenAIOption {
+	return func(o *openaiOptions) {
+		o.baseURL = baseURL
+	}
 }


### PR DESCRIPTION
This pull request introduces support for configuring a custom base URL for the OpenAI client in the transcription service. This enhancement allows users to specify alternative endpoints for OpenAI API requests, which is useful for testing, proxying, or using regional deployments.