### PR TITLE
Enhance Chat and ChatStream methods to preserve text content with tool calls

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -430,7 +430,10 @@ func (a *Agent) Chat(ctx context.Context, userMessage string) (*ChatResponse, er
 
 		assistantMsg := message.NewAssistantMessage()
 		assistantMsg.Model = a.llm.Model().ID
-		assistantMsg.SetToolCalls(resp.ToolCalls)
+		if resp.Content != "" {
+			assistantMsg.AppendContent(resp.Content)
+		}
+		assistantMsg.AppendToolCalls(resp.ToolCalls)
 		messages = append(messages, assistantMsg)
 
 		toolResults := a.executeTools(ctx, resp.ToolCalls)
@@ -534,7 +537,10 @@ func (a *Agent) ChatStream(ctx context.Context, userMessage string) <-chan ChatE
 
 			assistantMsg := message.NewAssistantMessage()
 			assistantMsg.Model = a.llm.Model().ID
-			assistantMsg.SetToolCalls(toolCalls)
+			if fullContent != "" {
+				assistantMsg.AppendContent(fullContent)
+			}
+			assistantMsg.AppendToolCalls(toolCalls)
 			messages = append(messages, assistantMsg)
 
 			for _, tc := range toolCalls {


### PR DESCRIPTION
This pull request updates how assistant messages are constructed in both the `Chat` and `ChatStream` methods of the `Agent` to ensure content and tool calls are appended correctly. The main change is switching from setting tool calls directly to appending them, and conditionally appending content only when present.
