### PR TITLE
chore: update integration module dependencies to v0.15.0

### DIFF
--- a/integrations/pgvector/go.mod
+++ b/integrations/pgvector/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai v0.14.0
+	github.com/joakimcarlsson/ai v0.15.0
 	github.com/lib/pq v1.11.2
 )
 

--- a/integrations/postgres/go.mod
+++ b/integrations/postgres/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai v0.14.0
+	github.com/joakimcarlsson/ai v0.15.0
 	github.com/lib/pq v1.11.2
 )
 

--- a/integrations/sqlite/go.mod
+++ b/integrations/sqlite/go.mod
@@ -2,6 +2,6 @@ module github.com/joakimcarlsson/ai/integrations/sqlite
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai v0.14.0
+require github.com/joakimcarlsson/ai v0.15.0
 
 replace github.com/joakimcarlsson/ai => ../..


### PR DESCRIPTION
## Summary
- Update `require` directive in all integration go.mod files from v0.14.0 to v0.15.0
- Required before tagging integration v1.0.0 releases so consumers resolve the correct root module version