### PR TITLE
feat: implement function tool wrapping and add example usage in docum…

### DIFF
--- a/example/agent/main.go
+++ b/example/agent/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/joakimcarlsson/ai/model"
 	llm "github.com/joakimcarlsson/ai/providers"
 	"github.com/joakimcarlsson/ai/tool"
+	"github.com/joakimcarlsson/ai/tool/functiontool"
 )
 
 type weatherParams struct {
@@ -56,12 +57,25 @@ func main() {
 		log.Fatal(err)
 	}
 
+	timeTool := functiontool.New(
+		"get_time",
+		"Get the current time in a city",
+		func(_ context.Context, p struct {
+			City string `json:"city" desc:"The city name"`
+		}) (string, error) {
+			return fmt.Sprintf(
+				"The current time in %s is 14:30 UTC",
+				p.City,
+			), nil
+		},
+	)
+
 	myAgent := agent.New(
 		llmClient,
 		agent.WithSystemPrompt(
-			"You are a helpful assistant with access to weather tools.",
+			"You are a helpful assistant with access to weather and time tools.",
 		),
-		agent.WithTools(&weatherTool{}),
+		agent.WithTools(&weatherTool{}, timeTool),
 		agent.WithSession("conv-1", session.FileStore("./sessions")),
 	)
 

--- a/example/function_tool/main.go
+++ b/example/function_tool/main.go
@@ -1,0 +1,88 @@
+// Example function_tool demonstrates wrapping plain Go functions as tools using functiontool.New.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/model"
+	llm "github.com/joakimcarlsson/ai/providers"
+	"github.com/joakimcarlsson/ai/tool/functiontool"
+)
+
+type weatherParams struct {
+	Location string `json:"location" desc:"The city name"`
+	Units    string `json:"units"    desc:"Temperature units" enum:"celsius,fahrenheit" required:"false"`
+}
+
+type userLookupParams struct {
+	Username string `json:"username" desc:"The username to look up"`
+}
+
+type userInfo struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
+func main() {
+	ctx := context.Background()
+
+	llmClient, err := llm.NewLLM(
+		model.ProviderOpenAI,
+		llm.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
+		llm.WithModel(model.OpenAIModels[model.GPT5Nano]),
+		llm.WithMaxTokens(2000),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	weatherTool := functiontool.New(
+		"get_weather",
+		"Get the current weather for a location",
+		func(_ context.Context, p weatherParams) (string, error) {
+			units := p.Units
+			if units == "" {
+				units = "celsius"
+			}
+			return fmt.Sprintf(
+				"The weather in %s is sunny, 22°%s",
+				p.Location,
+				units,
+			), nil
+		},
+	)
+
+	userTool := functiontool.New(
+		"lookup_user",
+		"Look up a user by username and return their profile",
+		func(p userLookupParams) (userInfo, error) {
+			return userInfo{
+				ID:       42,
+				Username: p.Username,
+				Email:    p.Username + "@example.com",
+			}, nil
+		},
+	)
+
+	myAgent := agent.New(
+		llmClient,
+		agent.WithSystemPrompt(
+			"You are a helpful assistant with access to weather and user lookup tools.",
+		),
+		agent.WithTools(weatherTool, userTool),
+	)
+
+	response, err := myAgent.Chat(
+		ctx,
+		"What's the weather in Paris? Also look up user 'alice'.",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(response.Content)
+}

--- a/tool/functiontool/functiontool.go
+++ b/tool/functiontool/functiontool.go
@@ -1,0 +1,200 @@
+// Package functiontool wraps plain Go functions as tool.BaseTool implementations.
+package functiontool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+var (
+	ctxType      = reflect.TypeOf((*context.Context)(nil)).Elem()
+	errorType    = reflect.TypeOf((*error)(nil)).Elem()
+	responseType = reflect.TypeOf(tool.Response{})
+)
+
+type returnStyle int
+
+const (
+	returnString returnStyle = iota
+	returnResponse
+	returnJSON
+)
+
+// Option configures a function tool created by New.
+type Option func(*funcTool)
+
+// WithConfirmation marks the tool as requiring human approval before execution.
+func WithConfirmation() Option {
+	return func(ft *funcTool) {
+		ft.info.RequireConfirmation = true
+	}
+}
+
+type funcTool struct {
+	info        tool.Info
+	fn          reflect.Value
+	hasCtx      bool
+	paramType   reflect.Type
+	returnStyle returnStyle
+}
+
+func (ft *funcTool) Info() tool.Info { return ft.info }
+
+func (ft *funcTool) Run(
+	ctx context.Context,
+	call tool.Call,
+) (tool.Response, error) {
+	var args []reflect.Value
+
+	if ft.hasCtx {
+		args = append(args, reflect.ValueOf(ctx))
+	}
+
+	if ft.paramType != nil {
+		paramPtr := reflect.New(ft.paramType)
+		if call.Input != "" {
+			if err := json.Unmarshal([]byte(call.Input), paramPtr.Interface()); err != nil {
+				return tool.NewTextErrorResponse(
+					"invalid input: " + err.Error(),
+				), nil
+			}
+		}
+		args = append(args, paramPtr.Elem())
+	}
+
+	var (
+		results []reflect.Value
+		fnErr   error
+	)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				fnErr = fmt.Errorf("tool panicked: %v", r)
+			}
+		}()
+		results = ft.fn.Call(args)
+	}()
+
+	if fnErr != nil {
+		return tool.NewTextErrorResponse(fnErr.Error()), nil
+	}
+
+	if errVal := results[1]; !errVal.IsNil() {
+		fnErr = errVal.Interface().(error)
+	}
+
+	if fnErr != nil {
+		if errors.Is(fnErr, tool.ErrConfirmationRejected) {
+			return tool.Response{}, fnErr
+		}
+		return tool.NewTextErrorResponse(fnErr.Error()), nil
+	}
+
+	switch ft.returnStyle {
+	case returnString:
+		return tool.NewTextResponse(results[0].String()), nil
+	case returnResponse:
+		return results[0].Interface().(tool.Response), nil
+	case returnJSON:
+		return tool.NewJSONResponse(results[0].Interface()), nil
+	default:
+		return tool.NewTextErrorResponse("unknown return style"), nil
+	}
+}
+
+// New wraps fn as a tool.BaseTool. The function's schema is inferred from
+// its parameter struct type. Panics if fn does not match a supported signature.
+func New(name, description string, fn any, opts ...Option) tool.BaseTool {
+	fnType := reflect.TypeOf(fn)
+	if fnType == nil || fnType.Kind() != reflect.Func {
+		panic("functiontool.New: fn must be a function")
+	}
+
+	numIn := fnType.NumIn()
+	if numIn > 2 {
+		panic(
+			"functiontool.New: fn must have at most 2 parameters (context.Context, ParamsStruct)",
+		)
+	}
+
+	var (
+		hasCtx    bool
+		paramType reflect.Type
+	)
+
+	idx := 0
+	if numIn > idx && fnType.In(idx).Implements(ctxType) {
+		hasCtx = true
+		idx++
+	}
+
+	if numIn > idx {
+		pt := fnType.In(idx)
+		if pt.Kind() == reflect.Ptr {
+			pt = pt.Elem()
+		}
+		if pt.Kind() != reflect.Struct {
+			panic("functiontool.New: parameter type must be a struct")
+		}
+		paramType = pt
+		idx++
+	}
+
+	if idx != numIn {
+		panic(
+			"functiontool.New: unexpected parameter types; expected ([context.Context], [ParamsStruct])",
+		)
+	}
+
+	if fnType.NumOut() != 2 {
+		panic(
+			"functiontool.New: fn must return exactly 2 values (result, error)",
+		)
+	}
+	if !fnType.Out(1).Implements(errorType) {
+		panic("functiontool.New: fn's second return value must implement error")
+	}
+
+	var rs returnStyle
+	switch fnType.Out(0) {
+	case reflect.TypeOf(""):
+		rs = returnString
+	case responseType:
+		rs = returnResponse
+	default:
+		rs = returnJSON
+	}
+
+	var info tool.Info
+	if paramType != nil {
+		info = tool.NewInfo(
+			name,
+			description,
+			reflect.New(paramType).Elem().Interface(),
+		)
+	} else {
+		info = tool.Info{
+			Name:        name,
+			Description: description,
+		}
+	}
+
+	ft := &funcTool{
+		info:        info,
+		fn:          reflect.ValueOf(fn),
+		hasCtx:      hasCtx,
+		paramType:   paramType,
+		returnStyle: rs,
+	}
+
+	for _, opt := range opts {
+		opt(ft)
+	}
+
+	return ft
+}

--- a/tool/functiontool/functiontool_test.go
+++ b/tool/functiontool/functiontool_test.go
@@ -1,0 +1,301 @@
+package functiontool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type greetParams struct {
+	Name string `json:"name" desc:"Person to greet"`
+}
+
+func TestNew_ContextAndParams_StringReturn(t *testing.T) {
+	ft := New(
+		"greet",
+		"Greet someone",
+		func(_ context.Context, p greetParams) (string, error) {
+			return "Hello " + p.Name, nil
+		},
+	)
+
+	info := ft.Info()
+	if info.Name != "greet" {
+		t.Errorf("expected name 'greet', got %q", info.Name)
+	}
+	if info.Description != "Greet someone" {
+		t.Errorf(
+			"expected description 'Greet someone', got %q",
+			info.Description,
+		)
+	}
+	if info.Parameters == nil {
+		t.Fatal("expected non-nil parameters")
+	}
+	if _, ok := info.Parameters["name"]; !ok {
+		t.Error("expected 'name' in parameters")
+	}
+	if len(info.Required) != 1 || info.Required[0] != "name" {
+		t.Errorf("expected required=[name], got %v", info.Required)
+	}
+
+	resp, err := ft.Run(
+		context.Background(),
+		tool.Call{ID: "1", Name: "greet", Input: `{"name":"Alice"}`},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Hello Alice" {
+		t.Errorf("expected 'Hello Alice', got %q", resp.Content)
+	}
+	if resp.IsError {
+		t.Error("expected IsError=false")
+	}
+}
+
+func TestNew_ParamsOnly_StringReturn(t *testing.T) {
+	ft := New("greet", "Greet", func(p greetParams) (string, error) {
+		return "Hi " + p.Name, nil
+	})
+
+	resp, err := ft.Run(
+		context.Background(),
+		tool.Call{Input: `{"name":"Bob"}`},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Hi Bob" {
+		t.Errorf("expected 'Hi Bob', got %q", resp.Content)
+	}
+}
+
+func TestNew_ContextOnly_NoParams(t *testing.T) {
+	ft := New("ping", "Ping", func(_ context.Context) (string, error) {
+		return "pong", nil
+	})
+
+	info := ft.Info()
+	if info.Parameters != nil {
+		t.Errorf("expected nil parameters, got %v", info.Parameters)
+	}
+
+	resp, err := ft.Run(context.Background(), tool.Call{Input: ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "pong" {
+		t.Errorf("expected 'pong', got %q", resp.Content)
+	}
+}
+
+func TestNew_NoInputs(t *testing.T) {
+	ft := New("hello", "Hello", func() (string, error) {
+		return "world", nil
+	})
+
+	info := ft.Info()
+	if info.Parameters != nil {
+		t.Errorf("expected nil parameters, got %v", info.Parameters)
+	}
+
+	resp, err := ft.Run(context.Background(), tool.Call{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "world" {
+		t.Errorf("expected 'world', got %q", resp.Content)
+	}
+}
+
+func TestNew_ResponseReturn(t *testing.T) {
+	ft := New("img", "Return image", func() (tool.Response, error) {
+		return tool.NewImageResponse("base64data"), nil
+	})
+
+	resp, err := ft.Run(context.Background(), tool.Call{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Type != tool.ResponseTypeImage {
+		t.Errorf("expected image type, got %s", resp.Type)
+	}
+	if resp.Content != "base64data" {
+		t.Errorf("expected 'base64data', got %q", resp.Content)
+	}
+}
+
+type userResult struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestNew_JSONReturn(t *testing.T) {
+	ft := New("user", "Get user", func(p greetParams) (userResult, error) {
+		return userResult{ID: 1, Name: p.Name}, nil
+	})
+
+	resp, err := ft.Run(
+		context.Background(),
+		tool.Call{Input: `{"name":"Eve"}`},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Type != tool.ResponseTypeJSON {
+		t.Errorf("expected json type, got %s", resp.Type)
+	}
+
+	var result userResult
+	if err := json.Unmarshal([]byte(resp.Content), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if result.Name != "Eve" || result.ID != 1 {
+		t.Errorf("unexpected result: %+v", result)
+	}
+}
+
+func TestNew_ErrorReturn(t *testing.T) {
+	ft := New("fail", "Fail", func() (string, error) {
+		return "", errors.New("something broke")
+	})
+
+	resp, err := ft.Run(context.Background(), tool.Call{})
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !resp.IsError {
+		t.Error("expected IsError=true")
+	}
+	if resp.Content != "something broke" {
+		t.Errorf("expected 'something broke', got %q", resp.Content)
+	}
+}
+
+func TestNew_ConfirmationRejected_PropagatedAsGoError(t *testing.T) {
+	ft := New("dangerous", "Dangerous", func() (string, error) {
+		return "", tool.ErrConfirmationRejected
+	})
+
+	_, err := ft.Run(context.Background(), tool.Call{})
+	if !errors.Is(err, tool.ErrConfirmationRejected) {
+		t.Errorf("expected ErrConfirmationRejected, got %v", err)
+	}
+}
+
+func TestNew_InvalidJSON(t *testing.T) {
+	ft := New("greet", "Greet", func(p greetParams) (string, error) {
+		return "Hi " + p.Name, nil
+	})
+
+	resp, err := ft.Run(context.Background(), tool.Call{Input: `{invalid`})
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !resp.IsError {
+		t.Error("expected IsError=true for invalid JSON")
+	}
+}
+
+func TestNew_PanicRecovery(t *testing.T) {
+	ft := New("boom", "Boom", func() (string, error) {
+		panic("kaboom")
+	})
+
+	resp, err := ft.Run(context.Background(), tool.Call{})
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !resp.IsError {
+		t.Error("expected IsError=true for panic")
+	}
+	if resp.Content != "tool panicked: kaboom" {
+		t.Errorf("expected panic message, got %q", resp.Content)
+	}
+}
+
+func TestWithConfirmation(t *testing.T) {
+	ft := New("del", "Delete", func() (string, error) {
+		return "deleted", nil
+	}, WithConfirmation())
+
+	if !ft.Info().RequireConfirmation {
+		t.Error("expected RequireConfirmation=true")
+	}
+}
+
+func TestNew_PanicsOnNonFunction(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for non-function")
+		}
+	}()
+	New("bad", "Bad", "not a function")
+}
+
+func TestNew_PanicsOnTooManyInputs(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for too many inputs")
+		}
+	}()
+	New(
+		"bad",
+		"Bad",
+		func(_ context.Context, _ greetParams, _ string) (string, error) {
+			return "", nil
+		},
+	)
+}
+
+func TestNew_PanicsOnWrongReturnCount(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for wrong return count")
+		}
+	}()
+	New("bad", "Bad", func() string { return "" })
+}
+
+func TestNew_PanicsOnNonErrorSecondReturn(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for non-error second return")
+		}
+	}()
+	New("bad", "Bad", func() (string, string) { return "", "" })
+}
+
+func TestNew_PanicsOnNonStructParam(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for non-struct param")
+		}
+	}()
+	New("bad", "Bad", func(s string) (string, error) { return s, nil })
+}
+
+func TestNew_RegistryIntegration(t *testing.T) {
+	ft := New("echo", "Echo", func(p greetParams) (string, error) {
+		return p.Name, nil
+	})
+
+	reg := tool.NewRegistry()
+	reg.Register(ft)
+
+	resp, err := reg.Execute(context.Background(), tool.Call{
+		ID:    "1",
+		Name:  "echo",
+		Input: `{"name":"test"}`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "test" {
+		t.Errorf("expected 'test', got %q", resp.Content)
+	}
+}

--- a/www/docs/advanced/tools.md
+++ b/www/docs/advanced/tools.md
@@ -23,6 +23,67 @@ func (w *WeatherTool) Run(ctx context.Context, params tool.Call) (tool.Response,
 }
 ```
 
+## Function Tools
+
+For simple tools that are just a function, use `functiontool.New` to skip the struct boilerplate:
+
+```go
+import "github.com/joakimcarlsson/ai/tool/functiontool"
+
+type WeatherParams struct {
+    Location string `json:"location" desc:"City name"`
+    Units    string `json:"units" desc:"Temperature units" enum:"celsius,fahrenheit" required:"false"`
+}
+
+weatherTool := functiontool.New("get_weather", "Get current weather for a location",
+    func(ctx context.Context, p WeatherParams) (string, error) {
+        return fmt.Sprintf("Sunny, 22°C in %s", p.Location), nil
+    },
+)
+```
+
+The JSON schema is inferred from the parameter struct using the same struct tags as `tool.NewInfo`. The result is a standard `BaseTool` that works with the registry, toolsets, hooks, and agent system.
+
+### Supported Signatures
+
+The function's first parameter can optionally be `context.Context`, and the second can be a struct for input parameters. Both are optional:
+
+```go
+// With context and params
+functiontool.New("name", "desc", func(ctx context.Context, p Params) (string, error) { ... })
+
+// Params only (no context)
+functiontool.New("name", "desc", func(p Params) (string, error) { ... })
+
+// Context only (no input schema)
+functiontool.New("name", "desc", func(ctx context.Context) (string, error) { ... })
+
+// No inputs at all
+functiontool.New("name", "desc", func() (string, error) { ... })
+```
+
+### Return Types
+
+The first return value determines the response type:
+
+```go
+// String → tool.NewTextResponse
+func(p Params) (string, error)
+
+// tool.Response → passed through directly
+func(p Params) (tool.Response, error)
+
+// Any other type → tool.NewJSONResponse (auto-marshaled)
+func(p Params) (MyStruct, error)
+```
+
+### Options
+
+```go
+// Require human confirmation before execution
+functiontool.New("delete", "Delete records", deleteFn, functiontool.WithConfirmation())
+```
+
 ## Using Tools with LLM
 
 ```go


### PR DESCRIPTION
This pull request introduces a new `functiontool` package for easily wrapping plain Go functions as tools, along with comprehensive tests, documentation, and usage examples. The main goal is to simplify tool creation by eliminating boilerplate and allowing developers to turn ordinary functions into `tool.BaseTool` implementations with schema inference and flexible signatures.