### PR TITLE
Task/106 add template field to spawn teammate for named instances

### DIFF
--- a/agent/team/team.go
+++ b/agent/team/team.go
@@ -10,8 +10,9 @@ import (
 
 // Config configures a team that a lead agent manages.
 type Config struct {
-	Name    string
-	MaxSize int
+	Name           string
+	MaxSize        int
+	DefaultTimeout time.Duration
 }
 
 // MemberStatus represents the lifecycle state of a teammate.
@@ -68,6 +69,11 @@ func (t *Team) Name() string {
 // MaxSize returns the team's maximum member count.
 func (t *Team) MaxSize() int {
 	return t.config.MaxSize
+}
+
+// DefaultTimeout returns the team's default timeout for teammates.
+func (t *Team) DefaultTimeout() time.Duration {
+	return t.config.DefaultTimeout
 }
 
 // AddMember registers a new teammate in the roster and mailbox.

--- a/agent/team_runner.go
+++ b/agent/team_runner.go
@@ -16,11 +16,18 @@ func spawnTeammate(
 	name string,
 	a *Agent,
 	task string,
+	timeout time.Duration,
 	hooks []Hooks,
 	eventChan chan<- ChatEvent,
 	opts ...ChatOption,
 ) (string, error) {
-	taskCtx, cancel := context.WithCancel(ctx)
+	var taskCtx context.Context
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		taskCtx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		taskCtx, cancel = context.WithCancel(ctx)
+	}
 
 	member, err := t.AddMember(name, task, cancel)
 	if err != nil {

--- a/agent/team_tools.go
+++ b/agent/team_tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/joakimcarlsson/ai/agent/team"
 	"github.com/joakimcarlsson/ai/tool"
@@ -16,6 +17,7 @@ type spawnTeammateInput struct {
 	Task         string `json:"task"          desc:"The task to assign to the teammate"`
 	SystemPrompt string `json:"system_prompt" desc:"System prompt for the teammate agent"              required:"false"`
 	MaxTurns     int    `json:"max_turns"     desc:"Maximum tool-execution turns. 0 uses default."     required:"false"`
+	Timeout      int    `json:"timeout"       desc:"Timeout in seconds for the teammate. 0 uses team default." required:"false"`
 }
 
 type spawnTeammateTool struct {
@@ -79,6 +81,13 @@ func (t *spawnTeammateTool) Run(
 		opts = append(opts, WithMaxTurns(input.MaxTurns))
 	}
 
+	var timeout time.Duration
+	if input.Timeout > 0 {
+		timeout = time.Duration(input.Timeout) * time.Second
+	} else {
+		timeout = tm.DefaultTimeout()
+	}
+
 	eventChan := teamEventChanFromContext(ctx)
 
 	memberID, err := spawnTeammate(
@@ -87,6 +96,7 @@ func (t *spawnTeammateTool) Run(
 		input.Name,
 		teammate,
 		input.Task,
+		timeout,
 		t.leadAgent.hooks,
 		eventChan,
 		opts...)

--- a/agent/team_tools.go
+++ b/agent/team_tools.go
@@ -12,6 +12,7 @@ import (
 
 type spawnTeammateInput struct {
 	Name         string `json:"name"          desc:"Unique name for the teammate (used for messaging)"`
+	Template     string `json:"template"      desc:"Template name to use for the teammate's configuration. Falls back to name if empty." required:"false"`
 	Task         string `json:"task"          desc:"The task to assign to the teammate"`
 	SystemPrompt string `json:"system_prompt" desc:"System prompt for the teammate agent"              required:"false"`
 	MaxTurns     int    `json:"max_turns"     desc:"Maximum tool-execution turns. 0 uses default."     required:"false"`
@@ -53,7 +54,11 @@ func (t *spawnTeammateTool) Run(
 	}
 
 	var teammate *Agent
-	if tmpl, ok := t.leadAgent.teammateTemplates[input.Name]; ok {
+	templateKey := input.Template
+	if templateKey == "" {
+		templateKey = input.Name
+	}
+	if tmpl, ok := t.leadAgent.teammateTemplates[templateKey]; ok {
 		teammate = tmpl
 	} else {
 		prompt := input.SystemPrompt


### PR DESCRIPTION
This pull request introduces configurable teammate timeouts in the team management system, allowing both team-wide and per-teammate timeout settings. The main changes add support for specifying a default timeout for all teammates at the team level, as well as allowing the timeout to be overridden when spawning individual teammates via the tool interface.
