### PR TITLE
fix: prevent lead agent from completing while teammates are active

### DIFF
--- a/agent/chat.go
+++ b/agent/chat.go
@@ -371,6 +371,26 @@ func (a *Agent) runLoop(
 		turns++
 		totalUsage.Add(resp.Usage)
 
+		if len(resp.ToolCalls) == 0 {
+			if t := team.FromContext(ctx); t != nil && t.ActiveCount() > 0 {
+				assistantMsg := message.NewAssistantMessage()
+				assistantMsg.Model = activeAgent.llm.Model().ID
+				if resp.Content != "" {
+					assistantMsg.AppendContent(resp.Content)
+				}
+				messages = append(messages, assistantMsg)
+				messages = append(messages, message.NewSystemMessage(
+					"You still have active teammates running. You MUST NOT produce a final response yet. "+
+						"Call list_teammates to check their status, then read_messages to get updates.",
+				))
+				if activeAgent.session != nil {
+					_ = activeAgent.session.AddMessages(ctx, []message.Message{assistantMsg})
+				}
+				iteration++
+				continue
+			}
+		}
+
 		if len(resp.ToolCalls) == 0 || !activeAgent.autoExecute ||
 			(maxIter > 0 && iteration >= maxIter) {
 			if activeAgent.session != nil {

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -501,6 +501,26 @@ func (a *Agent) runLoopStream(
 			fullContent = finalResponse.Content
 		}
 
+		if len(toolCalls) == 0 {
+			if t := team.FromContext(ctx); t != nil && t.ActiveCount() > 0 {
+				assistantMsg := message.NewAssistantMessage()
+				assistantMsg.Model = activeAgent.llm.Model().ID
+				if fullContent != "" {
+					assistantMsg.AppendContent(fullContent)
+				}
+				messages = append(messages, assistantMsg)
+				messages = append(messages, message.NewSystemMessage(
+					"You still have active teammates running. You MUST NOT produce a final response yet. "+
+						"Call list_teammates to check their status, then read_messages to get updates.",
+				))
+				if activeAgent.session != nil {
+					_ = activeAgent.session.AddMessages(ctx, []message.Message{assistantMsg})
+				}
+				iteration++
+				continue
+			}
+		}
+
 		if len(toolCalls) == 0 || !activeAgent.autoExecute ||
 			(maxIter > 0 && iteration >= maxIter) {
 			if activeAgent.session != nil {


### PR DESCRIPTION
The agent loop allows the lead to produce a final response (no tool calls) even when team members are still running. Weaker models ignore the prompt-level instruction to keep polling, causing premature completion and lost teammate results.

Insert a guard before the "done" branch in both runLoop and runLoopStream: when the model returns zero tool calls but ActiveCount() > 0, append the assistant message plus a system nudge and re-enter the loop. The iteration counter still increments, so maxIterations remains the upper bound.