### PR TITLE
Task/119 OpenAI and gemini providers do not emit eventthinkingdelta for reasoning models

### DIFF
--- a/example/reasoning_anthropic/main.go
+++ b/example/reasoning_anthropic/main.go
@@ -1,0 +1,45 @@
+// Example reasoning_anthropic demonstrates streaming extended thinking from an Anthropic model.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	llm "github.com/joakimcarlsson/ai/providers"
+	"github.com/joakimcarlsson/ai/types"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := llm.NewLLM(
+		model.ProviderAnthropic,
+		llm.WithAPIKey(""),
+		llm.WithModel(model.AnthropicModels[model.Claude4Sonnet]),
+		llm.WithMaxTokens(16000),
+		llm.WithAnthropicOptions(
+			llm.WithAnthropicReasoningEffort(llm.AnthropicReasoningEffortMedium),
+		),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	messages := []message.Message{
+		message.NewUserMessage("How many r's are in the word 'strawberry'?"),
+	}
+
+	for event := range client.StreamResponse(ctx, messages, nil) {
+		switch event.Type {
+		case types.EventThinkingDelta:
+			fmt.Print(event.Thinking)
+		case types.EventContentDelta:
+			fmt.Print(event.Content)
+		case types.EventError:
+			log.Fatal(event.Error)
+		}
+	}
+}

--- a/example/reasoning_gemini/main.go
+++ b/example/reasoning_gemini/main.go
@@ -1,0 +1,45 @@
+// Example reasoning_gemini demonstrates streaming thinking output from a Gemini model.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	llm "github.com/joakimcarlsson/ai/providers"
+	"github.com/joakimcarlsson/ai/types"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := llm.NewLLM(
+		model.ProviderGemini,
+		llm.WithAPIKey(""),
+		llm.WithModel(model.GeminiModels[model.Gemini3Pro]),
+		llm.WithMaxTokens(16000),
+		llm.WithGeminiOptions(
+			llm.WithGeminiThinkingLevel(llm.GeminiThinkingLevelMedium),
+		),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	messages := []message.Message{
+		message.NewUserMessage("How many r's are in the word 'strawberry'?"),
+	}
+
+	for event := range client.StreamResponse(ctx, messages, nil) {
+		switch event.Type {
+		case types.EventThinkingDelta:
+			fmt.Print(event.Thinking)
+		case types.EventContentDelta:
+			fmt.Print(event.Content)
+		case types.EventError:
+			log.Fatal(event.Error)
+		}
+	}
+}

--- a/example/reasoning_ollama/main.go
+++ b/example/reasoning_ollama/main.go
@@ -1,4 +1,4 @@
-// Example reasoning_openai demonstrates configuring reasoning effort for an OpenAI o-series model.
+// Example reasoning_ollama demonstrates streaming thinking output from an Ollama model via the OpenAI-compatible API.
 package main
 
 import (
@@ -17,11 +17,19 @@ func main() {
 
 	client, err := llm.NewLLM(
 		model.ProviderOpenAI,
-		llm.WithAPIKey(""),
-		llm.WithModel(model.OpenAIModels[model.O4Mini]),
-		llm.WithMaxTokens(16000),
+		llm.WithAPIKey("ollama"),
+		llm.WithModel(model.Model{
+			ID:               "qwen3:14b",
+			Name:             "Qwen3 14B",
+			APIModel:         "qwen3:14b",
+			Provider:         model.ProviderOpenAI,
+			ContextWindow:    32768,
+			DefaultMaxTokens: 4096,
+			CanReason:        true,
+		}),
+		llm.WithMaxTokens(4096),
 		llm.WithOpenAIOptions(
-			llm.WithReasoningEffort(llm.OpenAIReasoningEffortMedium),
+			llm.WithOpenAIBaseURL("http://localhost:11434/v1"),
 		),
 	)
 	if err != nil {
@@ -34,6 +42,8 @@ func main() {
 
 	for event := range client.StreamResponse(ctx, messages, nil) {
 		switch event.Type {
+		case types.EventThinkingDelta:
+			fmt.Print(event.Thinking)
 		case types.EventContentDelta:
 			fmt.Print(event.Content)
 		case types.EventError:

--- a/example/reasoning_openai/main.go
+++ b/example/reasoning_openai/main.go
@@ -1,0 +1,45 @@
+// Example reasoning_openai demonstrates streaming reasoning output from an OpenAI o-series model.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	llm "github.com/joakimcarlsson/ai/providers"
+	"github.com/joakimcarlsson/ai/types"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := llm.NewLLM(
+		model.ProviderOpenAI,
+		llm.WithAPIKey(""),
+		llm.WithModel(model.OpenAIModels[model.O4Mini]),
+		llm.WithMaxTokens(16000),
+		llm.WithOpenAIOptions(
+			llm.WithReasoningEffort(llm.OpenAIReasoningEffortMedium),
+		),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	messages := []message.Message{
+		message.NewUserMessage("How many r's are in the word 'strawberry'?"),
+	}
+
+	for event := range client.StreamResponse(ctx, messages, nil) {
+		switch event.Type {
+		case types.EventThinkingDelta:
+			fmt.Print(event.Thinking)
+		case types.EventContentDelta:
+			fmt.Print(event.Content)
+		case types.EventError:
+			log.Fatal(event.Error)
+		}
+	}
+}

--- a/providers/anthropic.go
+++ b/providers/anthropic.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/bedrock"
@@ -20,6 +21,7 @@ import (
 // AnthropicReasoningEffort controls thinking depth for Anthropic models.
 type AnthropicReasoningEffort string
 
+// AnthropicReasoningEffort values.
 const (
 	AnthropicReasoningEffortLow    AnthropicReasoningEffort = "low"
 	AnthropicReasoningEffortMedium AnthropicReasoningEffort = "medium"
@@ -229,18 +231,28 @@ func (a *anthropicClient) preparedMessages(
 	)
 
 	if a.options.reasoningEffort != nil && a.llmOptions.model.CanReason {
-		thinkingParam = anthropic.ThinkingConfigParamUnion{
-			OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{},
-		}
-		switch *a.options.reasoningEffort {
-		case AnthropicReasoningEffortLow:
-			outputConfig.Effort = anthropic.OutputConfigEffortLow
-		case AnthropicReasoningEffortMedium:
-			outputConfig.Effort = anthropic.OutputConfigEffortMedium
-		case AnthropicReasoningEffortHigh:
-			outputConfig.Effort = anthropic.OutputConfigEffortHigh
-		case AnthropicReasoningEffortMax:
-			outputConfig.Effort = anthropic.OutputConfigEffortMax
+		temperature = anthropic.Float(1)
+		apiModel := a.llmOptions.model.APIModel
+		if strings.Contains(apiModel, "4-6") || strings.Contains(apiModel, "4.6") {
+			thinkingParam = anthropic.ThinkingConfigParamUnion{
+				OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{},
+			}
+			switch *a.options.reasoningEffort {
+			case AnthropicReasoningEffortLow:
+				outputConfig.Effort = anthropic.OutputConfigEffortLow
+			case AnthropicReasoningEffortMedium:
+				outputConfig.Effort = anthropic.OutputConfigEffortMedium
+			case AnthropicReasoningEffortHigh:
+				outputConfig.Effort = anthropic.OutputConfigEffortHigh
+			case AnthropicReasoningEffortMax:
+				outputConfig.Effort = anthropic.OutputConfigEffortMax
+			}
+		} else {
+			thinkingParam = anthropic.ThinkingConfigParamUnion{
+				OfEnabled: &anthropic.ThinkingConfigEnabledParam{
+					BudgetTokens: int64(float64(a.llmOptions.maxTokens) * 0.8),
+				},
+			}
 		}
 	}
 

--- a/providers/anthropic.go
+++ b/providers/anthropic.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/bedrock"
@@ -18,10 +17,20 @@ import (
 	"github.com/joakimcarlsson/ai/types"
 )
 
+// AnthropicReasoningEffort controls thinking depth for Anthropic models.
+type AnthropicReasoningEffort string
+
+const (
+	AnthropicReasoningEffortLow    AnthropicReasoningEffort = "low"
+	AnthropicReasoningEffortMedium AnthropicReasoningEffort = "medium"
+	AnthropicReasoningEffortHigh   AnthropicReasoningEffort = "high"
+	AnthropicReasoningEffortMax    AnthropicReasoningEffort = "max"
+)
+
 type anthropicOptions struct {
-	useBedrock   bool
-	disableCache bool
-	shouldThink  func(userMessage string) bool
+	useBedrock      bool
+	disableCache    bool
+	reasoningEffort *AnthropicReasoningEffort
 }
 
 // AnthropicOption configures optional settings for Anthropic clients.
@@ -212,31 +221,26 @@ func (a *anthropicClient) preparedMessages(
 	systemMessages []string,
 ) anthropic.MessageNewParams {
 	var thinkingParam anthropic.ThinkingConfigParamUnion
-	lastMessage := messages[len(messages)-1]
-	isUser := lastMessage.Role == anthropic.MessageParamRoleUser
-	messageContent := ""
+	var outputConfig anthropic.OutputConfigParam
 	temperature := anthropic.Float(0)
 	paramBuilder := newParameterBuilder(a.llmOptions)
 	paramBuilder.applyFloat64Temperature(
 		func(t *float64) { temperature = anthropic.Float(*t) },
 	)
-	if isUser {
-		for _, m := range lastMessage.Content {
-			if m.OfText != nil && m.OfText.Text != "" {
-				messageContent = m.OfText.Text
-			}
+
+	if a.options.reasoningEffort != nil && a.llmOptions.model.CanReason {
+		thinkingParam = anthropic.ThinkingConfigParamUnion{
+			OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{},
 		}
-		if messageContent != "" && a.options.shouldThink != nil &&
-			a.options.shouldThink(messageContent) {
-			thinkingParam = anthropic.ThinkingConfigParamUnion{
-				OfEnabled: &anthropic.ThinkingConfigEnabledParam{
-					BudgetTokens: int64(float64(a.llmOptions.maxTokens) * 0.8),
-					Type:         "enabled",
-				},
-			}
-			if a.llmOptions.temperature == nil {
-				temperature = anthropic.Float(1)
-			}
+		switch *a.options.reasoningEffort {
+		case AnthropicReasoningEffortLow:
+			outputConfig.Effort = anthropic.OutputConfigEffortLow
+		case AnthropicReasoningEffortMedium:
+			outputConfig.Effort = anthropic.OutputConfigEffortMedium
+		case AnthropicReasoningEffortHigh:
+			outputConfig.Effort = anthropic.OutputConfigEffortHigh
+		case AnthropicReasoningEffortMax:
+			outputConfig.Effort = anthropic.OutputConfigEffortMax
 		}
 	}
 
@@ -247,12 +251,13 @@ func (a *anthropicClient) preparedMessages(
 	}
 
 	params := anthropic.MessageNewParams{
-		Model:       anthropic.Model(a.llmOptions.model.APIModel),
-		MaxTokens:   a.llmOptions.maxTokens,
-		Temperature: temperature,
-		Messages:    messages,
-		Tools:       tools,
-		Thinking:    thinkingParam,
+		Model:        anthropic.Model(a.llmOptions.model.APIModel),
+		MaxTokens:    a.llmOptions.maxTokens,
+		Temperature:  temperature,
+		Messages:     messages,
+		Tools:        tools,
+		Thinking:     thinkingParam,
+		OutputConfig: outputConfig,
 	}
 
 	paramBuilder.applyFloat64TopP(
@@ -496,15 +501,10 @@ func WithAnthropicDisableCache() AnthropicOption {
 	}
 }
 
-// DefaultShouldThinkFn checks if the user message contains "think" to enable reasoning mode
-func DefaultShouldThinkFn(s string) bool {
-	return strings.Contains(strings.ToLower(s), "think")
-}
-
-// WithAnthropicShouldThinkFn sets a custom function to determine when to enable reasoning mode
-func WithAnthropicShouldThinkFn(fn func(string) bool) AnthropicOption {
+// WithAnthropicReasoningEffort sets the reasoning effort level for Anthropic models.
+func WithAnthropicReasoningEffort(effort AnthropicReasoningEffort) AnthropicOption {
 	return func(options *anthropicOptions) {
-		options.shouldThink = fn
+		options.reasoningEffort = &effort
 	}
 }
 

--- a/providers/gemini.go
+++ b/providers/gemini.go
@@ -14,11 +14,22 @@ import (
 	"google.golang.org/genai"
 )
 
+// GeminiThinkingLevel controls thinking depth for Gemini models.
+type GeminiThinkingLevel string
+
+const (
+	GeminiThinkingLevelMinimal GeminiThinkingLevel = "minimal"
+	GeminiThinkingLevelLow     GeminiThinkingLevel = "low"
+	GeminiThinkingLevelMedium  GeminiThinkingLevel = "medium"
+	GeminiThinkingLevelHigh    GeminiThinkingLevel = "high"
+)
+
 type geminiOptions struct {
 	disableCache     bool
 	frequencyPenalty *float64
 	presencePenalty  *float64
 	seed             *int64
+	thinkingLevel    *GeminiThinkingLevel
 }
 
 // GeminiOption configures optional settings for Gemini clients.
@@ -173,6 +184,26 @@ func (g *geminiClient) finishReason(
 	}
 }
 
+func (g *geminiClient) applyThinkingConfig(config *genai.GenerateContentConfig) {
+	if g.options.thinkingLevel == nil || !g.providerOptions.model.CanReason {
+		return
+	}
+	tc := &genai.ThinkingConfig{
+		IncludeThoughts: true,
+	}
+	switch *g.options.thinkingLevel {
+	case GeminiThinkingLevelMinimal:
+		tc.ThinkingLevel = genai.ThinkingLevelMinimal
+	case GeminiThinkingLevelLow:
+		tc.ThinkingLevel = genai.ThinkingLevelLow
+	case GeminiThinkingLevelMedium:
+		tc.ThinkingLevel = genai.ThinkingLevelMedium
+	case GeminiThinkingLevelHigh:
+		tc.ThinkingLevel = genai.ThinkingLevelHigh
+	}
+	config.ThinkingConfig = tc
+}
+
 func (g *geminiClient) send(
 	ctx context.Context,
 	messages []message.Message,
@@ -202,6 +233,7 @@ func (g *geminiClient) send(
 		func(pp *float32) { config.PresencePenalty = pp },
 	)
 	params.applyInt32Seed(g.options.seed, func(s *int32) { config.Seed = s })
+	g.applyThinkingConfig(config)
 
 	if len(g.providerOptions.stopSequences) > 0 {
 		config.StopSequences = g.providerOptions.stopSequences
@@ -246,6 +278,7 @@ func (g *geminiClient) send(
 			if len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil {
 				for _, part := range resp.Candidates[0].Content.Parts {
 					switch {
+					case part.Thought && part.Text != "":
 					case part.Text != "":
 						content = string(part.Text)
 					case part.FunctionCall != nil:
@@ -308,6 +341,7 @@ func (g *geminiClient) stream(
 		func(pp *float32) { config.PresencePenalty = pp },
 	)
 	params.applyInt32Seed(g.options.seed, func(s *int32) { config.Seed = s })
+	g.applyThinkingConfig(config)
 
 	if len(g.providerOptions.stopSequences) > 0 {
 		config.StopSequences = g.providerOptions.stopSequences
@@ -363,6 +397,11 @@ func (g *geminiClient) stream(
 					resp.Candidates[0].Content != nil {
 					for _, part := range resp.Candidates[0].Content.Parts {
 						switch {
+						case part.Thought && part.Text != "":
+							eventChan <- Event{
+								Type:     types.EventThinkingDelta,
+								Thinking: string(part.Text),
+							}
 						case part.Text != "":
 							delta := string(part.Text)
 							currentContent += delta
@@ -467,6 +506,13 @@ func WithGeminiPresencePenalty(presencePenalty float64) GeminiOption {
 func WithGeminiSeed(seed int64) GeminiOption {
 	return func(options *geminiOptions) {
 		options.seed = &seed
+	}
+}
+
+// WithGeminiThinkingLevel sets the thinking level for Gemini models that support reasoning.
+func WithGeminiThinkingLevel(level GeminiThinkingLevel) GeminiOption {
+	return func(options *geminiOptions) {
+		options.thinkingLevel = &level
 	}
 }
 
@@ -586,6 +632,7 @@ func (g *geminiClient) sendWithStructuredOutput(
 		func(pp *float32) { config.PresencePenalty = pp },
 	)
 	params.applyInt32Seed(g.options.seed, func(s *int32) { config.Seed = s })
+	g.applyThinkingConfig(config)
 
 	geminiTools := g.convertTools(tools)
 	if len(geminiTools) > 0 {
@@ -620,7 +667,7 @@ func (g *geminiClient) sendWithStructuredOutput(
 			content := ""
 			for _, candidate := range response.Candidates {
 				for _, part := range candidate.Content.Parts {
-					if part.Text != "" {
+					if part.Text != "" && !part.Thought {
 						content += string(part.Text)
 					}
 				}
@@ -700,6 +747,7 @@ func (g *geminiClient) streamWithStructuredOutput(
 		func(pp *float32) { config.PresencePenalty = pp },
 	)
 	params.applyInt32Seed(g.options.seed, func(s *int32) { config.Seed = s })
+	g.applyThinkingConfig(config)
 
 	if len(g.providerOptions.stopSequences) > 0 {
 		config.StopSequences = g.providerOptions.stopSequences
@@ -755,6 +803,11 @@ func (g *geminiClient) streamWithStructuredOutput(
 					resp.Candidates[0].Content != nil {
 					for _, part := range resp.Candidates[0].Content.Parts {
 						switch {
+						case part.Thought && part.Text != "":
+							eventChan <- Event{
+								Type:     types.EventThinkingDelta,
+								Thinking: string(part.Text),
+							}
 						case part.Text != "":
 							delta := string(part.Text)
 							currentContent += delta

--- a/providers/gemini.go
+++ b/providers/gemini.go
@@ -17,6 +17,7 @@ import (
 // GeminiThinkingLevel controls thinking depth for Gemini models.
 type GeminiThinkingLevel string
 
+// GeminiThinkingLevel values.
 const (
 	GeminiThinkingLevelMinimal GeminiThinkingLevel = "minimal"
 	GeminiThinkingLevelLow     GeminiThinkingLevel = "low"

--- a/providers/openai.go
+++ b/providers/openai.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,10 +17,19 @@ import (
 	"github.com/openai/openai-go/shared"
 )
 
+// OpenAIReasoningEffort controls reasoning depth for OpenAI o-series models.
+type OpenAIReasoningEffort string
+
+const (
+	OpenAIReasoningEffortLow    OpenAIReasoningEffort = "low"
+	OpenAIReasoningEffortMedium OpenAIReasoningEffort = "medium"
+	OpenAIReasoningEffortHigh   OpenAIReasoningEffort = "high"
+)
+
 type openaiOptions struct {
 	baseURL           string
 	disableCache      bool
-	reasoningEffort   string
+	reasoningEffort   *OpenAIReasoningEffort
 	extraHeaders      map[string]string
 	frequencyPenalty  *float64
 	presencePenalty   *float64
@@ -40,9 +50,7 @@ type openaiClient struct {
 type OpenAIClient Client
 
 func newOpenAIClient(opts llmClientOptions) OpenAIClient {
-	openaiOpts := openaiOptions{
-		reasoningEffort: "medium",
-	}
+	openaiOpts := openaiOptions{}
 	for _, o := range opts.openaiOptions {
 		o(&openaiOpts)
 	}
@@ -262,15 +270,15 @@ func (o *openaiClient) preparedParams(
 
 	if o.providerOptions.model.CanReason {
 		params.MaxCompletionTokens = openai.Int(o.providerOptions.maxTokens)
-		switch o.options.reasoningEffort {
-		case "low":
-			params.ReasoningEffort = shared.ReasoningEffortLow
-		case "medium":
-			params.ReasoningEffort = shared.ReasoningEffortMedium
-		case "high":
-			params.ReasoningEffort = shared.ReasoningEffortHigh
-		default:
-			params.ReasoningEffort = shared.ReasoningEffortMedium
+		if o.options.reasoningEffort != nil {
+			switch *o.options.reasoningEffort {
+			case OpenAIReasoningEffortLow:
+				params.ReasoningEffort = shared.ReasoningEffortLow
+			case OpenAIReasoningEffortMedium:
+				params.ReasoningEffort = shared.ReasoningEffortMedium
+			case OpenAIReasoningEffortHigh:
+				params.ReasoningEffort = shared.ReasoningEffortHigh
+			}
 		}
 	} else {
 		params.MaxTokens = openai.Int(o.providerOptions.maxTokens)
@@ -364,6 +372,16 @@ func (o *openaiClient) stream(
 				acc.AddChunk(chunk)
 
 				for _, choice := range chunk.Choices {
+					if field, ok := choice.Delta.JSON.ExtraFields["reasoning_content"]; ok && field.Valid() {
+						var reasoningContent string
+						if json.Unmarshal([]byte(field.Raw()), &reasoningContent) == nil && reasoningContent != "" {
+							eventChan <- Event{
+								Type:     types.EventThinkingDelta,
+								Thinking: reasoningContent,
+							}
+						}
+					}
+
 					if choice.Delta.Content != "" {
 						eventChan <- Event{
 							Type:    types.EventContentDelta,
@@ -465,16 +483,10 @@ func WithOpenAIDisableCache() OpenAIOption {
 	}
 }
 
-// WithReasoningEffort sets the computational effort level for reasoning models (low, medium, high)
-func WithReasoningEffort(effort string) OpenAIOption {
+// WithReasoningEffort sets the reasoning effort level for OpenAI o-series models.
+func WithReasoningEffort(effort OpenAIReasoningEffort) OpenAIOption {
 	return func(options *openaiOptions) {
-		defaultReasoningEffort := "medium"
-		switch effort {
-		case "low", "medium", "high":
-			defaultReasoningEffort = effort
-		default:
-		}
-		options.reasoningEffort = defaultReasoningEffort
+		options.reasoningEffort = &effort
 	}
 }
 
@@ -639,6 +651,16 @@ func (o *openaiClient) streamWithStructuredOutput(
 				acc.AddChunk(chunk)
 
 				for _, choice := range chunk.Choices {
+					if field, ok := choice.Delta.JSON.ExtraFields["reasoning_content"]; ok && field.Valid() {
+						var reasoningContent string
+						if json.Unmarshal([]byte(field.Raw()), &reasoningContent) == nil && reasoningContent != "" {
+							eventChan <- Event{
+								Type:     types.EventThinkingDelta,
+								Thinking: reasoningContent,
+							}
+						}
+					}
+
 					if choice.Delta.Content != "" {
 						eventChan <- Event{
 							Type:    types.EventContentDelta,

--- a/providers/openai.go
+++ b/providers/openai.go
@@ -20,6 +20,7 @@ import (
 // OpenAIReasoningEffort controls reasoning depth for OpenAI o-series models.
 type OpenAIReasoningEffort string
 
+// OpenAIReasoningEffort values.
 const (
 	OpenAIReasoningEffortLow    OpenAIReasoningEffort = "low"
 	OpenAIReasoningEffortMedium OpenAIReasoningEffort = "medium"
@@ -372,13 +373,16 @@ func (o *openaiClient) stream(
 				acc.AddChunk(chunk)
 
 				for _, choice := range chunk.Choices {
-					if field, ok := choice.Delta.JSON.ExtraFields["reasoning_content"]; ok && field.Valid() {
-						var reasoningContent string
-						if json.Unmarshal([]byte(field.Raw()), &reasoningContent) == nil && reasoningContent != "" {
-							eventChan <- Event{
-								Type:     types.EventThinkingDelta,
-								Thinking: reasoningContent,
+					for _, key := range []string{"reasoning", "reasoning_content"} {
+						if field, ok := choice.Delta.JSON.ExtraFields[key]; ok && field.Raw() != "" {
+							var rc string
+							if json.Unmarshal([]byte(field.Raw()), &rc) == nil && rc != "" {
+								eventChan <- Event{
+									Type:     types.EventThinkingDelta,
+									Thinking: rc,
+								}
 							}
+							break
 						}
 					}
 
@@ -651,13 +655,16 @@ func (o *openaiClient) streamWithStructuredOutput(
 				acc.AddChunk(chunk)
 
 				for _, choice := range chunk.Choices {
-					if field, ok := choice.Delta.JSON.ExtraFields["reasoning_content"]; ok && field.Valid() {
-						var reasoningContent string
-						if json.Unmarshal([]byte(field.Raw()), &reasoningContent) == nil && reasoningContent != "" {
-							eventChan <- Event{
-								Type:     types.EventThinkingDelta,
-								Thinking: reasoningContent,
+					for _, key := range []string{"reasoning", "reasoning_content"} {
+						if field, ok := choice.Delta.JSON.ExtraFields[key]; ok && field.Raw() != "" {
+							var rc string
+							if json.Unmarshal([]byte(field.Raw()), &rc) == nil && rc != "" {
+								eventChan <- Event{
+									Type:     types.EventThinkingDelta,
+									Thinking: rc,
+								}
 							}
+							break
 						}
 					}
 

--- a/www/docs/advanced/configuration.md
+++ b/www/docs/advanced/configuration.md
@@ -105,9 +105,7 @@ llm.WithAnthropicOptions(
     llm.WithAnthropicBeta("beta-feature"),
     llm.WithAnthropicBedrock(true),
     llm.WithAnthropicDisableCache(),
-    llm.WithAnthropicShouldThinkFn(func(userMsg string) bool {
-        return strings.Contains(userMsg, "think")
-    }),
+    llm.WithAnthropicReasoningEffort(llm.AnthropicReasoningEffortMedium),
 )
 
 // OpenAI
@@ -115,7 +113,7 @@ llm.WithOpenAIOptions(
     llm.WithOpenAIBaseURL("custom-endpoint"),
     llm.WithOpenAIExtraHeaders(map[string]string{"Custom-Header": "value"}),
     llm.WithOpenAIDisableCache(),
-    llm.WithReasoningEffort("high"),                // "low", "medium", "high"
+    llm.WithReasoningEffort(llm.OpenAIReasoningEffortHigh),
     llm.WithOpenAIFrequencyPenalty(0.5),
     llm.WithOpenAIPresencePenalty(0.3),
     llm.WithOpenAISeed(42),

--- a/www/docs/advanced/reasoning.md
+++ b/www/docs/advanced/reasoning.md
@@ -1,0 +1,100 @@
+# Reasoning / Extended Thinking
+
+Models that support chain-of-thought reasoning can expose their internal thinking process via `EventThinkingDelta` streaming events.
+
+## Provider Setup
+
+=== "OpenAI"
+
+    ```go
+    client, err := llm.NewLLM(
+        model.ProviderOpenAI,
+        llm.WithAPIKey("your-key"),
+        llm.WithModel(model.OpenAIModels[model.O4Mini]),
+        llm.WithMaxTokens(16000),
+        llm.WithOpenAIOptions(
+            llm.WithReasoningEffort(llm.OpenAIReasoningEffortHigh),
+        ),
+    )
+    ```
+
+    | Level | Constant |
+    |-------|----------|
+    | Low | `OpenAIReasoningEffortLow` |
+    | Medium | `OpenAIReasoningEffortMedium` |
+    | High | `OpenAIReasoningEffortHigh` |
+
+=== "Anthropic"
+
+    ```go
+    client, err := llm.NewLLM(
+        model.ProviderAnthropic,
+        llm.WithAPIKey("your-key"),
+        llm.WithModel(model.AnthropicModels[model.Claude4Sonnet]),
+        llm.WithMaxTokens(16000),
+        llm.WithAnthropicOptions(
+            llm.WithAnthropicReasoningEffort(llm.AnthropicReasoningEffortHigh),
+        ),
+    )
+    ```
+
+    | Level | Constant |
+    |-------|----------|
+    | Low | `AnthropicReasoningEffortLow` |
+    | Medium | `AnthropicReasoningEffortMedium` |
+    | High | `AnthropicReasoningEffortHigh` |
+    | Max | `AnthropicReasoningEffortMax` |
+
+=== "Gemini"
+
+    ```go
+    client, err := llm.NewLLM(
+        model.ProviderGemini,
+        llm.WithAPIKey("your-key"),
+        llm.WithModel(model.GeminiModels[model.Gemini3Pro]),
+        llm.WithMaxTokens(16000),
+        llm.WithGeminiOptions(
+            llm.WithGeminiThinkingLevel(llm.GeminiThinkingLevelHigh),
+        ),
+    )
+    ```
+
+    | Level | Constant |
+    |-------|----------|
+    | Minimal | `GeminiThinkingLevelMinimal` |
+    | Low | `GeminiThinkingLevelLow` |
+    | Medium | `GeminiThinkingLevelMedium` |
+    | High | `GeminiThinkingLevelHigh` |
+
+## Streaming Thinking Events
+
+```go
+for event := range client.StreamResponse(ctx, messages, nil) {
+    switch event.Type {
+    case types.EventThinkingDelta:
+        fmt.Print(event.Thinking)
+    case types.EventContentDelta:
+        fmt.Print(event.Content)
+    case types.EventComplete:
+        fmt.Printf("\nTokens: %d in, %d out\n",
+            event.Response.Usage.InputTokens,
+            event.Response.Usage.OutputTokens,
+        )
+    case types.EventError:
+        log.Fatal(event.Error)
+    }
+}
+```
+
+The same pattern works with agents via `ChatStream`:
+
+```go
+for event := range myAgent.ChatStream(ctx, "Think about this carefully...") {
+    switch event.Type {
+    case types.EventThinkingDelta:
+        fmt.Print(event.Thinking)
+    case types.EventContentDelta:
+        fmt.Print(event.Content)
+    }
+}
+```

--- a/www/docs/advanced/reasoning.md
+++ b/www/docs/advanced/reasoning.md
@@ -1,8 +1,10 @@
 # Reasoning / Extended Thinking
 
-Models that support chain-of-thought reasoning can expose their internal thinking process via `EventThinkingDelta` streaming events.
+Models that support chain-of-thought reasoning can be configured to control reasoning depth. Some providers also expose the model's thinking process via `EventThinkingDelta` streaming events.
 
-## Provider Setup
+## Reasoning Effort
+
+Controls how much effort the model spends on internal reasoning before generating a response.
 
 === "OpenAI"
 
@@ -23,6 +25,8 @@ Models that support chain-of-thought reasoning can expose their internal thinkin
     | Low | `OpenAIReasoningEffortLow` |
     | Medium | `OpenAIReasoningEffortMedium` |
     | High | `OpenAIReasoningEffortHigh` |
+
+    OpenAI's Chat Completions API does not expose thinking content. The model reasons internally but `EventThinkingDelta` events are not emitted.
 
 === "Anthropic"
 
@@ -68,6 +72,8 @@ Models that support chain-of-thought reasoning can expose their internal thinkin
 
 ## Streaming Thinking Events
 
+Anthropic, Gemini, and OpenAI-compatible providers (Ollama, vLLM, etc.) stream thinking content via `EventThinkingDelta`:
+
 ```go
 for event := range client.StreamResponse(ctx, messages, nil) {
     switch event.Type {
@@ -97,4 +103,28 @@ for event := range myAgent.ChatStream(ctx, "Think about this carefully...") {
         fmt.Print(event.Content)
     }
 }
+```
+
+## OpenAI-Compatible Providers
+
+Providers like Ollama and vLLM that serve reasoning models (Qwen, DeepSeek, etc.) via an OpenAI-compatible API do stream thinking content. Use a custom model with `WithOpenAIBaseURL`:
+
+```go
+client, err := llm.NewLLM(
+    model.ProviderOpenAI,
+    llm.WithAPIKey("ollama"),
+    llm.WithModel(model.Model{
+        ID:               "qwen3:14b",
+        Name:             "Qwen3 14B",
+        APIModel:         "qwen3:14b",
+        Provider:         model.ProviderOpenAI,
+        ContextWindow:    32768,
+        DefaultMaxTokens: 4096,
+        CanReason:        true,
+    }),
+    llm.WithMaxTokens(4096),
+    llm.WithOpenAIOptions(
+        llm.WithOpenAIBaseURL("http://localhost:11434/v1"),
+    ),
+)
 ```

--- a/www/docs/agent/streaming.md
+++ b/www/docs/agent/streaming.md
@@ -10,7 +10,7 @@ for event := range myAgent.ChatStream(ctx, "Tell me a story") {
     case types.EventContentDelta:
         fmt.Print(event.Content)
     case types.EventThinkingDelta:
-        // Extended thinking content (if supported)
+        fmt.Print(event.Thinking)
     case types.EventToolUseStart:
         fmt.Printf("\nUsing tool: %s\n", event.ToolCall.Name)
     case types.EventToolUseStop:

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - MCP Integration: advanced/mcp.md
     - Tool Calling: advanced/tools.md
     - Structured Output: advanced/structured-output.md
+    - Reasoning: advanced/reasoning.md
     - Cost Tracking: advanced/cost-tracking.md
     - Prompt Templates: advanced/prompt-templates.md
     - OpenTelemetry Tracing: advanced/tracing.md


### PR DESCRIPTION
closes #119 

This pull request introduces support for configuring and streaming "reasoning" or "thinking" output from Anthropic, Gemini, and OpenAI models, including new options to control the depth or effort of reasoning for each provider. It also adds example programs demonstrating how to use these features with each provider. The changes enhance the SDK's capability to surface intermediate reasoning steps from models that support this feature, and provide a consistent API for customizing reasoning effort.