### PR TITLE
chore: add Claude 4.7 Opus model to Anthropic and OpenRouter registries

### DIFF
--- a/model/anthropic.go
+++ b/model/anthropic.go
@@ -16,6 +16,7 @@ const (
 	Claude45Haiku  ID = "claude-4.5-haiku"
 	Claude46Opus   ID = "claude-4.6-opus"
 	Claude46Sonnet ID = "claude-4.6-sonnet"
+	Claude47Opus   ID = "claude-4.7-opus"
 )
 
 // AnthropicModels maps Anthropic model IDs to their configurations.
@@ -191,6 +192,21 @@ var AnthropicModels = map[ID]Model{
 		CostPer1MOut:          15.0,
 		ContextWindow:         200000,
 		DefaultMaxTokens:      64000,
+		CanReason:             true,
+		SupportsAttachments:   true,
+		SupportsStructuredOut: true,
+	},
+	Claude47Opus: {
+		ID:                    Claude47Opus,
+		Name:                  "Claude 4.7 Opus",
+		Provider:              ProviderAnthropic,
+		APIModel:              "claude-opus-4-7-latest",
+		CostPer1MIn:           5.0,
+		CostPer1MInCached:     6.25,
+		CostPer1MOutCached:    0.50,
+		CostPer1MOut:          25.0,
+		ContextWindow:         1000000,
+		DefaultMaxTokens:      128000,
 		CanReason:             true,
 		SupportsAttachments:   true,
 		SupportsStructuredOut: true,

--- a/model/openrouter.go
+++ b/model/openrouter.go
@@ -31,6 +31,7 @@ const (
 	OpenRouterClaude45Opus      ID = "openrouter.claude-4.5-opus"
 	OpenRouterClaude46Opus      ID = "openrouter.claude-4.6-opus"
 	OpenRouterClaude46Sonnet    ID = "openrouter.claude-4.6-sonnet"
+	OpenRouterClaude47Opus      ID = "openrouter.claude-4.7-opus"
 	OpenRouterGPT52Codex        ID = "openrouter.gpt-5.2-codex"
 	OpenRouterMistralLarge3     ID = "openrouter.mistral-large-3"
 	OpenRouterMistralMedium3    ID = "openrouter.mistral-medium-3"
@@ -413,6 +414,20 @@ var OpenRouterModels = map[ID]Model{
 		DefaultMaxTokens:      AnthropicModels[Claude46Opus].DefaultMaxTokens,
 		CanReason:             AnthropicModels[Claude46Opus].CanReason,
 		SupportsStructuredOut: AnthropicModels[Claude46Opus].SupportsStructuredOut,
+	},
+	OpenRouterClaude47Opus: {
+		ID:                    OpenRouterClaude47Opus,
+		Name:                  "OpenRouter – Claude 4.7 Opus",
+		Provider:              ProviderOpenRouter,
+		APIModel:              "anthropic/claude-opus-4.7",
+		CostPer1MIn:           AnthropicModels[Claude47Opus].CostPer1MIn,
+		CostPer1MInCached:     AnthropicModels[Claude47Opus].CostPer1MInCached,
+		CostPer1MOut:          AnthropicModels[Claude47Opus].CostPer1MOut,
+		CostPer1MOutCached:    AnthropicModels[Claude47Opus].CostPer1MOutCached,
+		ContextWindow:         AnthropicModels[Claude47Opus].ContextWindow,
+		DefaultMaxTokens:      AnthropicModels[Claude47Opus].DefaultMaxTokens,
+		CanReason:             AnthropicModels[Claude47Opus].CanReason,
+		SupportsStructuredOut: AnthropicModels[Claude47Opus].SupportsStructuredOut,
 	},
 	OpenRouterClaude46Sonnet: {
 		ID:                    OpenRouterClaude46Sonnet,


### PR DESCRIPTION
This pull request adds support for the new Claude 4.7 Opus model from Anthropic and its corresponding OpenRouter variant. The changes include defining new constants and model configurations to enable usage and correct pricing for these models.
