### PR TITLE
llm/openai: bump openai-go to v3

### DIFF
--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/joakimcarlsson/ai/schema v0.1.0
 	github.com/joakimcarlsson/ai/tool v0.1.0
 	github.com/joakimcarlsson/ai/types v0.1.0
-	github.com/openai/openai-go v1.12.0
 )
 
 require (
@@ -22,6 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.0 // indirect
+	github.com/openai/openai-go/v3 v3.35.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/llm/openai/go.sum
+++ b/llm/openai/go.sum
@@ -25,6 +25,8 @@ github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8
 github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
 github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.35.0 h1:109x3epXMSE423KW2euR506GGFezcEt0s87MoWejpH0=
+github.com/openai/openai-go/v3 v3.35.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -19,9 +19,9 @@ import (
 	"github.com/joakimcarlsson/ai/schema"
 	"github.com/joakimcarlsson/ai/tool"
 	"github.com/joakimcarlsson/ai/types"
-	openaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/shared"
+	openaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/shared"
 )
 
 // ReasoningEffort controls reasoning depth for OpenAI o-series models.
@@ -303,16 +303,17 @@ func (c *Client) convertMessages(
 
 			if len(msg.ToolCalls()) > 0 {
 				assistantMsg.ToolCalls = make(
-					[]openaisdk.ChatCompletionMessageToolCallParam,
+					[]openaisdk.ChatCompletionMessageToolCallUnionParam,
 					len(msg.ToolCalls()),
 				)
 				for i, call := range msg.ToolCalls() {
-					assistantMsg.ToolCalls[i] = openaisdk.ChatCompletionMessageToolCallParam{
-						ID:   call.ID,
-						Type: "function",
-						Function: openaisdk.ChatCompletionMessageToolCallFunctionParam{
-							Name:      call.Name,
-							Arguments: call.Input,
+					assistantMsg.ToolCalls[i] = openaisdk.ChatCompletionMessageToolCallUnionParam{
+						OfFunction: &openaisdk.ChatCompletionMessageFunctionToolCallParam{
+							ID: call.ID,
+							Function: openaisdk.ChatCompletionMessageFunctionToolCallFunctionParam{
+								Name:      call.Name,
+								Arguments: call.Input,
+							},
 						},
 					}
 				}
@@ -339,8 +340,8 @@ func (c *Client) convertMessages(
 
 func (c *Client) convertTools(
 	tools []tool.BaseTool,
-) []openaisdk.ChatCompletionToolParam {
-	out := make([]openaisdk.ChatCompletionToolParam, len(tools))
+) []openaisdk.ChatCompletionToolUnionParam {
+	out := make([]openaisdk.ChatCompletionToolUnionParam, len(tools))
 
 	for i, t := range tools {
 		info := t.Info()
@@ -351,11 +352,13 @@ func (c *Client) convertTools(
 		if len(info.Required) > 0 {
 			params["required"] = info.Required
 		}
-		out[i] = openaisdk.ChatCompletionToolParam{
-			Function: openaisdk.FunctionDefinitionParam{
-				Name:        info.Name,
-				Description: openaisdk.String(info.Description),
-				Parameters:  params,
+		out[i] = openaisdk.ChatCompletionToolUnionParam{
+			OfFunction: &openaisdk.ChatCompletionFunctionToolParam{
+				Function: openaisdk.FunctionDefinitionParam{
+					Name:        info.Name,
+					Description: openaisdk.String(info.Description),
+					Parameters:  params,
+				},
 			},
 		}
 	}
@@ -378,7 +381,7 @@ func (c *Client) finishReason(reason string) message.FinishReason {
 
 func (c *Client) preparedParams(
 	messages []openaisdk.ChatCompletionMessageParamUnion,
-	tools []openaisdk.ChatCompletionToolParam,
+	tools []openaisdk.ChatCompletionToolUnionParam,
 ) openaisdk.ChatCompletionNewParams {
 	params := openaisdk.ChatCompletionNewParams{
 		Model:    openaisdk.ChatModel(c.options.model.APIModel),


### PR DESCRIPTION
## Summary
- Migrate `llm/openai` to `github.com/openai/openai-go/v3`
- Adapt to v3 union-type API for tool calls (`ChatCompletionMessageToolCallUnionParam`, `ChatCompletionToolUnionParam`)

## Test plan
- [x] Builds clean against v3
- [x] Smoke test against live Azure OpenAI deployment via downstream `llm/azure` returns structured signals