### PR TITLE
fix(azure): support OpenAI-compatible v1 endpoint shape

### DIFF
--- a/llm/azure/azure.go
+++ b/llm/azure/azure.go
@@ -6,6 +6,7 @@
 package azure
 
 import (
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -136,6 +137,21 @@ func NewLLM(opts ...Option) llm.LLM {
 				openaiOpts,
 				llmopenai.WithAPIKey(options.apiKey),
 			)
+		}
+		return llmopenai.NewLLM(openaiOpts...)
+	}
+
+	// Azure's v1 endpoint (".../openai/v1") is OpenAI-compatible: it does not
+	// accept the api-version query param and uses /chat/completions directly,
+	// not /openai/deployments/<name>/chat/completions. Route via the plain
+	// OpenAI client with WithBaseURL.
+	if strings.Contains(options.endpoint, "/openai/v1") {
+		openaiOpts = append(
+			openaiOpts,
+			llmopenai.WithBaseURL(strings.TrimRight(options.endpoint, "/")),
+		)
+		if options.apiKey != "" {
+			openaiOpts = append(openaiOpts, llmopenai.WithAPIKey(options.apiKey))
 		}
 		return llmopenai.NewLLM(openaiOpts...)
 	}


### PR DESCRIPTION
## Summary
- Detect endpoints containing `/openai/v1` and route through plain OpenAI client with `WithBaseURL` instead of the Azure-specific URL builder
- Legacy `*.openai.azure.com` endpoint path is unchanged

## Why
Azure now offers an OpenAI-compatible v1 endpoint (`.../openai/v1`). The legacy adapter path appends `?api-version=...` and rewrites the URL to `/openai/deployments/<name>/chat/completions`, which the v1 endpoint rejects.

## Test plan
- [x] Build clean
- [x] Smoke-tested against live `https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1` — structured-output extraction returns expected signals