### PR TITLE
feat(tts): add StreamingTextProvider for incremental text-to-audio

### DIFF
--- a/tts/deepgram/deepgram.go
+++ b/tts/deepgram/deepgram.go
@@ -248,33 +248,9 @@ func (c *Client) StreamAudio(
 	text string,
 	_ ...tts.GenerationOption,
 ) (<-chan tts.Chunk, error) {
-	wsURL, err := c.buildStreamURL()
+	conn, send, err := c.dialStreamWS(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build ws url: %w", err)
-	}
-
-	hdr := http.Header{}
-	hdr.Set("Authorization", "Token "+c.options.apiKey)
-
-	dialer := websocket.Dialer{HandshakeTimeout: wsHandshakeTimeout}
-	conn, resp, err := dialer.DialContext(ctx, wsURL, hdr)
-	if resp != nil {
-		_ = resp.Body.Close()
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial websocket: %w", err)
-	}
-
-	_ = conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
-	conn.SetPongHandler(func(string) error {
-		return conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
-	})
-
-	var writeMu sync.Mutex
-	send := func(data []byte) error {
-		writeMu.Lock()
-		defer writeMu.Unlock()
-		return conn.WriteMessage(websocket.TextMessage, data)
+		return nil, err
 	}
 
 	speak, err := json.Marshal(speakMessage{Type: "Speak", Text: text})
@@ -292,7 +268,110 @@ func (c *Client) StreamAudio(
 	}
 
 	chunkChan := make(chan tts.Chunk, 10)
-	go runStreamReader(ctx, conn, chunkChan, send)
+	go runStreamReader(ctx, conn, chunkChan, send, true)
+	return chunkChan, nil
+}
+
+// dialStreamWS opens the WS to Deepgram's /v1/speak endpoint and returns the
+// connection along with a goroutine-safe send function.
+func (c *Client) dialStreamWS(
+	ctx context.Context,
+) (*websocket.Conn, func([]byte) error, error) {
+	wsURL, err := c.buildStreamURL()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build ws url: %w", err)
+	}
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Token "+c.options.apiKey)
+
+	dialer := websocket.Dialer{HandshakeTimeout: wsHandshakeTimeout}
+	conn, resp, err := dialer.DialContext(ctx, wsURL, hdr)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to dial websocket: %w", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
+	})
+
+	var writeMu sync.Mutex
+	send := func(data []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteMessage(websocket.TextMessage, data)
+	}
+
+	return conn, send, nil
+}
+
+// StreamAudioFromText opens a WebSocket to Deepgram and sends a Speak frame for
+// each piece received on textIn (with an immediate Flush so audio for that piece
+// starts generating). Closing textIn sends Close, which triggers a final Flushed
+// frame before the connection terminates. Implements [tts.StreamingTextProvider].
+//
+// Like [StreamAudio], this requires a raw audio encoding (linear16, mulaw, alaw);
+// the WS endpoint does not accept compressed encodings.
+func (c *Client) StreamAudioFromText(
+	ctx context.Context,
+	textIn <-chan string,
+	_ ...tts.GenerationOption,
+) (<-chan tts.Chunk, error) {
+	conn, send, err := c.dialStreamWS(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	chunkChan := make(chan tts.Chunk, 10)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				_ = send([]byte(`{"type":"Close"}`))
+				return
+			case piece, ok := <-textIn:
+				if !ok {
+					_ = send([]byte(`{"type":"Close"}`))
+					return
+				}
+				if piece == "" {
+					continue
+				}
+				speak, mErr := json.Marshal(
+					speakMessage{Type: "Speak", Text: piece},
+				)
+				if mErr != nil {
+					select {
+					case chunkChan <- tts.Chunk{Error: fmt.Errorf("failed to marshal speak: %w", mErr)}:
+					case <-ctx.Done():
+					}
+					_ = send([]byte(`{"type":"Close"}`))
+					return
+				}
+				if sErr := send(speak); sErr != nil {
+					select {
+					case chunkChan <- tts.Chunk{Error: fmt.Errorf("failed to send speak: %w", sErr)}:
+					case <-ctx.Done():
+					}
+					return
+				}
+				if fErr := send([]byte(`{"type":"Flush"}`)); fErr != nil {
+					select {
+					case chunkChan <- tts.Chunk{Error: fmt.Errorf("failed to send flush: %w", fErr)}:
+					case <-ctx.Done():
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	go runStreamReader(ctx, conn, chunkChan, send, false)
 	return chunkChan, nil
 }
 
@@ -353,6 +432,7 @@ func runStreamReader(
 	conn *websocket.Conn,
 	out chan<- tts.Chunk,
 	send func([]byte) error,
+	closeOnFlushed bool,
 ) {
 	defer close(out)
 	defer func() { _ = conn.Close() }()
@@ -389,6 +469,12 @@ func runStreamReader(
 				}
 				switch srv.Type {
 				case "Flushed":
+					if !closeOnFlushed {
+						// streaming-text path: each Flushed is just a per-chunk
+						// boundary. Keep the connection open until the caller
+						// closes textIn (which sends a Close frame).
+						continue
+					}
 					select {
 					case out <- tts.Chunk{Done: true}:
 					case <-ctx.Done():
@@ -396,7 +482,10 @@ func runStreamReader(
 					_ = send([]byte(`{"type":"Close"}`))
 					_ = conn.WriteControl(
 						websocket.CloseMessage,
-						websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+						websocket.FormatCloseMessage(
+							websocket.CloseNormalClosure,
+							"",
+						),
 						time.Now().Add(2*time.Second),
 					)
 					return

--- a/tts/elevenlabs/elevenlabs.go
+++ b/tts/elevenlabs/elevenlabs.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -98,7 +99,8 @@ type Client struct {
 
 // NewGeneration constructs an ElevenLabs TTS client. The returned [tts.Generation]
 // is wrapped with [tts.WithTracing]; the wrapper preserves [tts.ForcedAlignmentProvider]
-// support so type assertion against the returned value succeeds.
+// and [tts.StreamingTextProvider] support so type assertions against the returned
+// value succeed.
 func NewGeneration(opts ...Option) tts.Generation {
 	options := Options{}
 	for _, o := range opts {
@@ -440,7 +442,8 @@ type wsBeginMessage struct {
 }
 
 type wsTextMessage struct {
-	Text string `json:"text"`
+	Text  string `json:"text"`
+	Flush bool   `json:"flush,omitempty"`
 }
 
 type wsServerMessage struct {
@@ -458,61 +461,9 @@ func (c *Client) streamWS(
 	text string,
 	opts *tts.GenerationOptions,
 ) (<-chan tts.Chunk, error) {
-	outputFormat := c.outputFormat
-	if opts.OutputFormat != "" {
-		outputFormat = opts.OutputFormat
-	}
-
-	wsURL, err := c.buildStreamURL(outputFormat, opts.EnableAlignment)
+	conn, send, err := c.dialStreamWS(ctx, opts)
 	if err != nil {
-		ch := make(chan tts.Chunk, 1)
-		ch <- tts.Chunk{Error: fmt.Errorf("failed to build ws url: %w", err)}
-		close(ch)
-		return ch, nil
-	}
-
-	hdr := http.Header{}
-	hdr.Set("xi-api-key", c.apiKey)
-
-	dialer := websocket.Dialer{HandshakeTimeout: wsHandshakeTimeout}
-	conn, resp, err := dialer.DialContext(ctx, wsURL, hdr)
-	if resp != nil {
-		_ = resp.Body.Close()
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial websocket: %w", err)
-	}
-
-	conn.SetReadLimit(wsReadLimit)
-	_ = conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
-	conn.SetPongHandler(func(string) error {
-		return conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
-	})
-
-	var writeMu sync.Mutex
-	send := func(messageType int, data []byte) error {
-		writeMu.Lock()
-		defer writeMu.Unlock()
-		return conn.WriteMessage(messageType, data)
-	}
-
-	bos, err := json.Marshal(wsBeginMessage{
-		Text:          " ",
-		VoiceSettings: c.buildVoiceSettings(opts),
-	})
-	if err != nil {
-		_ = conn.Close()
-		ch := make(chan tts.Chunk, 1)
-		ch <- tts.Chunk{Error: fmt.Errorf("failed to marshal bos: %w", err)}
-		close(ch)
-		return ch, nil
-	}
-	if err := send(websocket.TextMessage, bos); err != nil {
-		_ = conn.Close()
-		ch := make(chan tts.Chunk, 1)
-		ch <- tts.Chunk{Error: fmt.Errorf("failed to send bos: %w", err)}
-		close(ch)
-		return ch, nil
+		return nil, err
 	}
 
 	textMsg, err := json.Marshal(wsTextMessage{Text: text + " "})
@@ -544,7 +495,133 @@ func (c *Client) streamWS(
 	return chunkChan, nil
 }
 
-func (c *Client) buildStreamURL(outputFormat string, syncAlignment bool) (string, error) {
+// dialStreamWS opens the WS to ElevenLabs, sends the BOS frame, and returns the
+// connection along with a goroutine-safe send function. The caller is responsible
+// for sending text frames, the EOS frame, and starting the reader.
+func (c *Client) dialStreamWS(
+	ctx context.Context,
+	opts *tts.GenerationOptions,
+) (*websocket.Conn, func(int, []byte) error, error) {
+	outputFormat := c.outputFormat
+	if opts.OutputFormat != "" {
+		outputFormat = opts.OutputFormat
+	}
+
+	wsURL, err := c.buildStreamURL(outputFormat, opts.EnableAlignment)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build ws url: %w", err)
+	}
+
+	hdr := http.Header{}
+	hdr.Set("xi-api-key", c.apiKey)
+
+	dialer := websocket.Dialer{HandshakeTimeout: wsHandshakeTimeout}
+	conn, resp, err := dialer.DialContext(ctx, wsURL, hdr)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to dial websocket: %w", err)
+	}
+
+	conn.SetReadLimit(wsReadLimit)
+	_ = conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
+	})
+
+	var writeMu sync.Mutex
+	send := func(messageType int, data []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteMessage(messageType, data)
+	}
+
+	bos, err := json.Marshal(wsBeginMessage{
+		Text:          " ",
+		VoiceSettings: c.buildVoiceSettings(opts),
+	})
+	if err != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("failed to marshal bos: %w", err)
+	}
+	if err := send(websocket.TextMessage, bos); err != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("failed to send bos: %w", err)
+	}
+
+	return conn, send, nil
+}
+
+// StreamAudioFromText opens a WebSocket to ElevenLabs and pumps text frames as
+// they arrive on textIn. Closing textIn signals end-of-input; the WS sends an
+// EOS frame and the audio channel closes once the server returns the final
+// frame. This is the streaming-text path used to forward LLM deltas with low
+// time-to-first-byte. Implements [tts.StreamingTextProvider].
+func (c *Client) StreamAudioFromText(
+	ctx context.Context,
+	textIn <-chan string,
+	options ...tts.GenerationOption,
+) (<-chan tts.Chunk, error) {
+	opts := &tts.GenerationOptions{}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	conn, send, err := c.dialStreamWS(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	chunkChan := make(chan tts.Chunk, 10)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				_ = send(websocket.TextMessage, []byte(`{"text":""}`))
+				return
+			case piece, ok := <-textIn:
+				if !ok {
+					_ = send(websocket.TextMessage, []byte(`{"text":""}`))
+					return
+				}
+				if piece == "" {
+					continue
+				}
+				if !strings.HasSuffix(piece, " ") {
+					piece += " "
+				}
+				msg, mErr := json.Marshal(
+					wsTextMessage{Text: piece, Flush: true},
+				)
+				if mErr != nil {
+					select {
+					case chunkChan <- tts.Chunk{Error: fmt.Errorf("failed to marshal text: %w", mErr)}:
+					case <-ctx.Done():
+					}
+					_ = send(websocket.TextMessage, []byte(`{"text":""}`))
+					return
+				}
+				if sErr := send(websocket.TextMessage, msg); sErr != nil {
+					select {
+					case chunkChan <- tts.Chunk{Error: fmt.Errorf("failed to send text: %w", sErr)}:
+					case <-ctx.Done():
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	go runStreamReader(ctx, conn, chunkChan)
+	return chunkChan, nil
+}
+
+func (c *Client) buildStreamURL(
+	outputFormat string,
+	syncAlignment bool,
+) (string, error) {
 	base, err := url.Parse(c.baseURL)
 	if err != nil {
 		return "", err
@@ -631,7 +708,9 @@ func runStreamReader(
 					chunk.Alignment = toAlignmentData(*srv.Alignment)
 				}
 				if srv.NormalizedAlignment != nil {
-					chunk.NormalizedAlignment = toAlignmentData(*srv.NormalizedAlignment)
+					chunk.NormalizedAlignment = toAlignmentData(
+						*srv.NormalizedAlignment,
+					)
 				}
 				select {
 				case out <- chunk:
@@ -647,7 +726,10 @@ func runStreamReader(
 				}
 				_ = conn.WriteControl(
 					websocket.CloseMessage,
-					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+					websocket.FormatCloseMessage(
+						websocket.CloseNormalClosure,
+						"",
+					),
 					time.Now().Add(2*time.Second),
 				)
 				return

--- a/tts/tts.go
+++ b/tts/tts.go
@@ -139,6 +139,22 @@ type ForcedAlignmentProvider interface {
 	) (*ForcedAlignmentData, error)
 }
 
+// StreamingTextProvider is an optional sub-interface for providers that accept
+// text incrementally and produce audio as the text arrives (e.g. forwarding LLM
+// deltas to a TTS WebSocket). Implementations consume textIn until the channel
+// is closed by the caller, then signal end-of-input to the provider.
+//
+// Detect support via type assertion on the [Generation] returned from a vendor's
+// NewGeneration constructor. The [WithTracing] wrapper preserves this interface
+// when the inner client implements it.
+type StreamingTextProvider interface {
+	StreamAudioFromText(
+		ctx context.Context,
+		textIn <-chan string,
+		options ...GenerationOption,
+	) (<-chan Chunk, error)
+}
+
 // GenerationOptions contains parameters for customizing audio generation requests.
 type GenerationOptions struct {
 	OutputFormat             string
@@ -200,15 +216,32 @@ type TracingAttrs struct {
 }
 
 // WithTracing wraps a Generation client so every call records OpenTelemetry spans
-// and metrics. If the inner client also implements [ForcedAlignmentProvider], the
-// returned wrapper does too — type assertion on the wrapper succeeds and the call
-// is traced and forwarded to the inner client.
+// and metrics. If the inner client also implements [ForcedAlignmentProvider] or
+// [StreamingTextProvider], the returned wrapper preserves those interfaces — type
+// assertions on the wrapper succeed and the call is traced and forwarded to the
+// inner client.
 func WithTracing(inner Generation, attrs TracingAttrs) Generation {
 	base := &tracingGeneration{inner: inner, attrs: attrs}
-	if fap, ok := inner.(ForcedAlignmentProvider); ok {
+	fap, hasFAP := inner.(ForcedAlignmentProvider)
+	stp, hasSTP := inner.(StreamingTextProvider)
+	switch {
+	case hasFAP && hasSTP:
+		return &tracingGenerationWithForcedAlignmentAndStreamingText{
+			tracingGenerationWithForcedAlignment: tracingGenerationWithForcedAlignment{
+				tracingGeneration: base,
+				fap:               fap,
+			},
+			stp: stp,
+		}
+	case hasFAP:
 		return &tracingGenerationWithForcedAlignment{
 			tracingGeneration: base,
 			fap:               fap,
+		}
+	case hasSTP:
+		return &tracingGenerationWithStreamingText{
+			tracingGeneration: base,
+			stp:               stp,
 		}
 	}
 	return base
@@ -366,4 +399,70 @@ func (t *tracingGenerationWithForcedAlignment) GenerateForcedAlignment(
 		time.Since(start), 0, 0, nil,
 	)
 	return resp, nil
+}
+
+// tracingGenerationWithStreamingText is the tracing wrapper used when the inner
+// Generation client also implements StreamingTextProvider.
+type tracingGenerationWithStreamingText struct {
+	*tracingGeneration
+	stp StreamingTextProvider
+}
+
+func (t *tracingGenerationWithStreamingText) StreamAudioFromText(
+	ctx context.Context,
+	textIn <-chan string,
+	options ...GenerationOption,
+) (<-chan Chunk, error) {
+	m := t.inner.Model()
+	start := time.Now()
+	ctx, span := tracing.StartAudioSpan(
+		ctx, m.APIModel, string(m.Provider), t.spanAttrs()...,
+	)
+
+	innerCh, err := t.stp.StreamAudioFromText(ctx, textIn, options...)
+	if err != nil {
+		tracing.SetError(span, err)
+		tracing.RecordMetrics(
+			ctx, "stream_audio_from_text", m.APIModel, string(m.Provider),
+			time.Since(start), 0, 0, err,
+		)
+		span.End()
+		return nil, err
+	}
+
+	outCh := make(chan Chunk)
+	go func() {
+		defer close(outCh)
+		defer span.End()
+		for chunk := range innerCh {
+			if chunk.Error != nil {
+				tracing.SetError(span, chunk.Error)
+			}
+			outCh <- chunk
+		}
+		tracing.RecordMetrics(
+			ctx, "stream_audio_from_text", m.APIModel, string(m.Provider),
+			time.Since(start), 0, 0, nil,
+		)
+	}()
+	return outCh, nil
+}
+
+// tracingGenerationWithForcedAlignmentAndStreamingText is the tracing wrapper
+// used when the inner Generation client implements both optional sub-interfaces.
+type tracingGenerationWithForcedAlignmentAndStreamingText struct {
+	tracingGenerationWithForcedAlignment
+	stp StreamingTextProvider
+}
+
+func (t *tracingGenerationWithForcedAlignmentAndStreamingText) StreamAudioFromText(
+	ctx context.Context,
+	textIn <-chan string,
+	options ...GenerationOption,
+) (<-chan Chunk, error) {
+	wrapper := &tracingGenerationWithStreamingText{
+		tracingGeneration: t.tracingGeneration,
+		stp:               t.stp,
+	}
+	return wrapper.StreamAudioFromText(ctx, textIn, options...)
 }


### PR DESCRIPTION
## Summary

- Add optional \`StreamingTextProvider\` sub-interface to \`tts\` so callers can feed text into a provider as it arrives (e.g. LLM deltas) instead of buffering the full response. Cuts time-to-first-audio in voice pipelines.
- Implement on \`tts/elevenlabs\` (existing \`/stream-input\` WS) and \`tts/deepgram\` (\`/v1/speak\` WS).
- \`WithTracing\` now preserves \`StreamingTextProvider\` through the tracing wrapper, with combined wrappers for clients that implement both \`StreamingTextProvider\` and \`ForcedAlignmentProvider\`.

## Protocol notes

- ElevenLabs: each frame sent with \`flush: true\` since the caller pre-chunks (per WS API docs). Closing the text channel sends \`{"text":""}\` as EOS.
- Deepgram: \`{"type":"Speak"}\` + \`{"type":"Flush"}\` per chunk; closing the text channel sends \`{"type":"Close"}\`. Reader gains a \`closeOnFlushed\` flag so the existing \`StreamAudio\` still terminates on first \`Flushed\` while the streaming-text path waits for connection close.

## Test plan

- [x] \`go build\`, \`go vet\`, \`golangci-lint run\` clean on \`tts\`, \`tts/elevenlabs\`, \`tts/deepgram\`
- [ ] End-to-end run against ElevenLabs WS from a downstream consumer
- [ ] End-to-end run against Deepgram WS

## Release

After merge, tag in order: \`tts/v0.2.0\` → bump \`tts\` requirement in \`tts/elevenlabs\` and \`tts/deepgram\` go.mods → \`tts/elevenlabs/v0.2.0\`, \`tts/deepgram/v0.2.0\`. Additive change, hence MINOR bump.