### PR TITLE
chore(tts): bump tts dependency to v0.2.0 in elevenlabs and deepgram

### DIFF
--- a/tts/deepgram/go.mod
+++ b/tts/deepgram/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.1.0
-	github.com/joakimcarlsson/ai/tts v0.1.0
+	github.com/joakimcarlsson/ai/tts v0.2.0
 )
 
 require (

--- a/tts/elevenlabs/go.mod
+++ b/tts/elevenlabs/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.1.0
-	github.com/joakimcarlsson/ai/tts v0.1.0
+	github.com/joakimcarlsson/ai/tts v0.2.0
 )
 
 require (


### PR DESCRIPTION
## Summary

- Bump \`github.com/joakimcarlsson/ai/tts\` from v0.1.0 to v0.2.0 in \`tts/elevenlabs\` and \`tts/deepgram\` so the new \`StreamingTextProvider\` interface added in #136 is reachable for consumers via type assertion against the value returned by \`NewGeneration\`.

## Test plan

- [x] \`go build\` clean in both modules