### PR TITLE
feat(voice): add initial message feature for conversation greetings

### DIFF
--- a/examples/voice/web/main.go
+++ b/examples/voice/web/main.go
@@ -172,6 +172,7 @@ func wsHandler(
 			sttClient,
 			ttsClient,
 			voice.WithSystemPrompt(systemPrompt),
+			voice.WithInitialMessage("Hi! How can I help you today?"),
 			voice.WithTools(currentTimeTool{}),
 			voice.WithSession("web-demo", sessionStore),
 			voice.WithContextStrategy(

--- a/tests/voice/initial_message_test.go
+++ b/tests/voice/initial_message_test.go
@@ -1,0 +1,368 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/session"
+	"github.com/joakimcarlsson/ai/stt"
+	"github.com/joakimcarlsson/ai/tts"
+	"github.com/joakimcarlsson/ai/voice"
+)
+
+// 1. With WithInitialMessage set, the agent speaks the greeting on a fresh
+// conversation. TTS is invoked with the configured text, the standard
+// event sequence fires, and no LLM call happens.
+func TestInitialMessage_SpeaksOnFreshConversation(t *testing.T) {
+	llmFake := newFakeLLM("init-speaks")
+	a := newTestAgent(t, llmFake, voice.WithInitialMessage("hello there"))
+	defer a.cancel()
+
+	waitFor(t, func() bool { return a.hasEvent(voice.EventAssistantDone) },
+		"assistant done after initial message")
+
+	deltas := a.eventsOfType(voice.EventAssistantDelta)
+	if len(deltas) == 0 || deltas[0].Text != "hello there" {
+		t.Fatalf("expected delta with greeting text; got %+v", deltas)
+	}
+	if !a.hasEvent(voice.EventTTSStarted) {
+		t.Fatalf("expected EventTTSStarted before greeting")
+	}
+	if !a.hasEvent(voice.EventTTSEnded) {
+		t.Fatalf("expected EventTTSEnded after greeting")
+	}
+	if llmFake.callCount() != 0 {
+		t.Fatalf("LLM should not be called for initial message; got %d calls",
+			llmFake.callCount())
+	}
+
+	a.cancel()
+	_ = a.conv.Wait()
+}
+
+// 2. When resuming a session that already has non-system messages, the
+// greeting is skipped — the user is mid-thread and should not hear a
+// fresh hello.
+func TestInitialMessage_SkippedOnSessionResume(t *testing.T) {
+	store := session.MemoryStore()
+	ctx := context.Background()
+	sess, _ := store.Create(ctx, "sess-resume")
+	_ = sess.AddMessages(ctx, []message.Message{
+		message.NewSystemMessage("you are helpful"),
+		message.NewUserMessage("earlier ask"),
+		message.NewMessage(message.Assistant,
+			[]message.ContentPart{message.TextContent{Text: "earlier reply"}}),
+	})
+
+	llmFake := newFakeLLM("init-skip-resume")
+	a := newTestAgent(t, llmFake,
+		voice.WithInitialMessage("hello again"),
+		voice.WithSystemPrompt("you are helpful"),
+		voice.WithSession("sess-resume", store),
+	)
+	defer a.cancel()
+
+	waitFor(t, func() bool { return a.hasEvent(voice.EventReady) },
+		"ready")
+
+	// 100ms grace: if a greeting were going to fire it would have by now.
+	time.Sleep(100 * time.Millisecond)
+	if a.hasEvent(voice.EventTTSStarted) {
+		t.Fatalf("expected greeting to be skipped on session resume; "+
+			"got events %+v", a.eventsOfType(voice.EventTTSStarted))
+	}
+
+	a.cancel()
+	_ = a.conv.Wait()
+}
+
+// 3. The greeting is appended to the session as an assistant message.
+func TestInitialMessage_PersistsToSession(t *testing.T) {
+	store := session.MemoryStore()
+	llmFake := newFakeLLM("init-persist")
+	a := newTestAgent(t, llmFake,
+		voice.WithInitialMessage("welcome"),
+		voice.WithSession("sess-init-persist", store),
+	)
+	defer a.cancel()
+
+	waitFor(t, func() bool { return a.hasEvent(voice.EventAssistantDone) },
+		"assistant done")
+
+	a.cancel()
+	_ = a.conv.Wait()
+
+	sess, _ := store.Load(context.Background(), "sess-init-persist")
+	msgs, _ := sess.GetMessages(context.Background(), nil)
+	if !anyAssistantText(msgs, "welcome") {
+		t.Fatalf("expected greeting persisted to session; got %+v", msgs)
+	}
+}
+
+// 4. Empty WithInitialMessage (or unset) is a no-op: no TTS, no events.
+func TestInitialMessage_EmptyIsNoOp(t *testing.T) {
+	llmFake := newFakeLLM("init-empty")
+	a := newTestAgent(t, llmFake, voice.WithInitialMessage(""))
+	defer a.cancel()
+
+	waitFor(t, func() bool { return a.hasEvent(voice.EventReady) },
+		"ready")
+
+	time.Sleep(100 * time.Millisecond)
+	if a.hasEvent(voice.EventTTSStarted) ||
+		a.hasEvent(voice.EventAssistantDone) {
+		t.Fatalf("expected no greeting events with empty initial message")
+	}
+
+	a.cancel()
+	_ = a.conv.Wait()
+}
+
+// 5. When the TTS client does not implement tts.StreamingTextProvider, the
+// greeting falls back to tts.Generation.StreamAudio (speakOneShot).
+func TestInitialMessage_NonStreamingFallback(t *testing.T) {
+	nstts := &nonStreamingTTS{}
+	llmFake := newFakeLLM("init-nonstream")
+	sttFake := newFakeSTT()
+	v := voice.New(llmFake, sttFake, nstts,
+		voice.WithInitialMessage("hi via one-shot"),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newFakeTransport()
+	conv, err := v.StartConversation(ctx, transport)
+	if err != nil {
+		t.Fatalf("StartConversation: %v", err)
+	}
+
+	var (
+		mu     sync.Mutex
+		events []voice.Event
+	)
+	go func() {
+		for evt := range conv.Events() {
+			mu.Lock()
+			events = append(events, evt)
+			mu.Unlock()
+		}
+	}()
+
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, e := range events {
+			if e.Type == voice.EventAssistantDone {
+				return true
+			}
+		}
+		return false
+	}, "assistant done via non-streaming")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if nstts.calls() != 1 {
+		t.Fatalf("expected StreamAudio called once for fallback; got %d",
+			nstts.calls())
+	}
+	if got := nstts.lastText(); got != "hi via one-shot" {
+		t.Fatalf("expected StreamAudio text 'hi via one-shot'; got %q", got)
+	}
+}
+
+// 6. Under BargeInInterrupt, a user partial during the greeting cancels TTS
+// and the assistant history entry is recorded with an "[interrupted]"
+// suffix. Uses a custom TTS that holds audio open until ctx cancels so the
+// barge-in window exists.
+func TestInitialMessage_BargeInTruncatesAndPersists(t *testing.T) {
+	store := session.MemoryStore()
+	holdingTTS := newHoldingTTS()
+
+	llmFake := newFakeLLM("init-barge")
+	sttFake := newFakeSTT()
+	v := voice.New(llmFake, sttFake, holdingTTS,
+		voice.WithInitialMessage("welcome to the agent"),
+		voice.WithBargeIn(voice.BargeInInterrupt),
+		voice.WithSession("sess-barge", store),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newFakeTransport()
+	conv, err := v.StartConversation(ctx, transport)
+	if err != nil {
+		t.Fatalf("StartConversation: %v", err)
+	}
+
+	var (
+		mu     sync.Mutex
+		events []voice.Event
+	)
+	go func() {
+		for evt := range conv.Events() {
+			mu.Lock()
+			events = append(events, evt)
+			mu.Unlock()
+		}
+	}()
+
+	hasEvt := func(want voice.EventType) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, e := range events {
+			if e.Type == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	waitFor(t, func() bool { return hasEvt(voice.EventTTSStarted) },
+		"TTS started for greeting")
+
+	sttFake.push(stt.StreamResult{Text: "stop", IsFinal: false})
+
+	waitFor(t, func() bool { return hasEvt(voice.EventAgentInterrupted) },
+		"EventAgentInterrupted fired during greeting")
+
+	waitFor(t, func() bool {
+		sess, _ := store.Load(context.Background(), "sess-barge")
+		msgs, _ := sess.GetMessages(context.Background(), nil)
+		return anyAssistantText(msgs, "[interrupted]")
+	}, "greeting persisted with [interrupted] suffix")
+
+	cancel()
+	_ = conv.Wait()
+}
+
+// anyAssistantText reports whether any persisted assistant message
+// contains the given substring in a TextContent part.
+func anyAssistantText(msgs []message.Message, want string) bool {
+	for _, m := range msgs {
+		if m.Role != message.Assistant {
+			continue
+		}
+		for _, p := range m.Parts {
+			if tc, ok := p.(message.TextContent); ok &&
+				strings.Contains(tc.Text, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// nonStreamingTTS implements tts.Generation but NOT
+// tts.StreamingTextProvider, so the initial-message path falls back to
+// speakOneShot.
+type nonStreamingTTS struct {
+	mu        sync.Mutex
+	callCount int
+	last      string
+}
+
+func (n *nonStreamingTTS) calls() int { n.mu.Lock(); defer n.mu.Unlock(); return n.callCount }
+func (n *nonStreamingTTS) lastText() string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.last
+}
+
+func (n *nonStreamingTTS) StreamAudio(
+	_ context.Context,
+	text string,
+	_ ...tts.GenerationOption,
+) (<-chan tts.Chunk, error) {
+	n.mu.Lock()
+	n.callCount++
+	n.last = text
+	n.mu.Unlock()
+	ch := make(chan tts.Chunk, 1)
+	ch <- tts.Chunk{Data: []byte{0x00}}
+	close(ch)
+	return ch, nil
+}
+
+func (n *nonStreamingTTS) GenerateAudio(
+	context.Context,
+	string,
+	...tts.GenerationOption,
+) (*tts.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (n *nonStreamingTTS) ListVoices(context.Context) ([]tts.Voice, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (n *nonStreamingTTS) Model() model.AudioModel { return model.AudioModel{} }
+
+// holdingTTS implements tts.StreamingTextProvider but keeps the audio
+// output channel open until ctx cancels, so a barge-in test has a
+// window to inject the interruption while the agent is in the audio
+// pump loop.
+type holdingTTS struct {
+	mu       sync.Mutex
+	received []string
+}
+
+func newHoldingTTS() *holdingTTS { return &holdingTTS{} }
+
+func (h *holdingTTS) StreamAudioFromText(
+	ctx context.Context,
+	textIn <-chan string,
+	_ ...tts.GenerationOption,
+) (<-chan tts.Chunk, error) {
+	out := make(chan tts.Chunk, 16)
+	go func() {
+		defer close(out)
+		// Drain textIn until closed, then block on ctx so the audio
+		// pump in speakInitialMessage stays open and barge-in has time
+		// to fire.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case text, ok := <-textIn:
+				if !ok {
+					<-ctx.Done()
+					return
+				}
+				h.mu.Lock()
+				h.received = append(h.received, text)
+				h.mu.Unlock()
+			}
+		}
+	}()
+	return out, nil
+}
+
+func (h *holdingTTS) StreamAudio(
+	context.Context,
+	string,
+	...tts.GenerationOption,
+) (<-chan tts.Chunk, error) {
+	ch := make(chan tts.Chunk)
+	close(ch)
+	return ch, nil
+}
+
+func (h *holdingTTS) GenerateAudio(
+	context.Context,
+	string,
+	...tts.GenerationOption,
+) (*tts.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (h *holdingTTS) ListVoices(context.Context) ([]tts.Voice, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (h *holdingTTS) Model() model.AudioModel { return model.AudioModel{} }

--- a/voice/doc.go
+++ b/voice/doc.go
@@ -15,6 +15,7 @@
 //
 //	v := voice.New(llmClient, sttClient, ttsClient,
 //	    voice.WithSystemPrompt("You are a helpful assistant."),
+//	    voice.WithInitialMessage("Hi, how can I help?"),
 //	    voice.WithTools(myTool),
 //	)
 //	conv, err := v.StartConversation(ctx, transport)

--- a/voice/options.go
+++ b/voice/options.go
@@ -19,6 +19,20 @@ func WithSystemPrompt(prompt string) Option {
 	}
 }
 
+// WithInitialMessage sets a fixed greeting the agent speaks once when a
+// conversation starts. The message is skipped when resuming a session that
+// already contains user or assistant messages. Empty disables the feature.
+//
+// The greeting participates in barge-in like any assistant turn: under
+// BargeInInterrupt, a user partial during the greeting cancels TTS, fires
+// EventAgentInterrupted, and records the history entry with an
+// "[interrupted]" suffix.
+func WithInitialMessage(msg string) Option {
+	return func(v *Agent) {
+		v.initialMessage = msg
+	}
+}
+
 // WithTools registers tools that the LLM may call during a conversation.
 // Multiple WithTools options append.
 func WithTools(tools ...tool.BaseTool) Option {

--- a/voice/pipeline.go
+++ b/voice/pipeline.go
@@ -376,6 +376,109 @@ func streamLLMAndSpeak(
 	return text, toolCalls, nil
 }
 
+// speakInitialMessage speaks a fixed greeting once at conversation start.
+// Mirrors the TTS half of streamLLMAndSpeak: streams via
+// tts.StreamingTextProvider when available, falls back to speakOneShot
+// otherwise. Honors barge-in via ctx cancellation — on cancel it closes
+// textIn and drains audioOut so the provider goroutine releases.
+//
+// Caller is responsible for setting up turnState (cancelTurn, dropAudio,
+// agentSpeaking, spokenSoFar) before calling, and for translating the
+// returned error into a history entry.
+func speakInitialMessage(
+	ctx context.Context,
+	v *Agent,
+	text string,
+	emit func(Event),
+	ttsAudio chan<- []byte,
+	state *turnState,
+) error {
+	emit(Event{Type: EventAssistantDelta, Timestamp: time.Now(), Text: text})
+	state.setSpoken(text)
+
+	stp, ok := v.tts.(tts.StreamingTextProvider)
+	if !ok {
+		if err := speakOneShot(ctx, v.tts, text, emit, ttsAudio); err != nil {
+			return err
+		}
+		emit(Event{Type: EventAssistantDone, Timestamp: time.Now(), Text: text})
+		return nil
+	}
+
+	ch := make(chan string, 1)
+	audioOut, err := stp.StreamAudioFromText(ctx, ch)
+	if err != nil {
+		close(ch)
+		return err
+	}
+	emit(Event{Type: EventTTSStarted, Timestamp: time.Now()})
+	state.agentSpeaking.Store(true)
+
+	textInClosed := false
+	closeTextIn := func() {
+		if !textInClosed {
+			textInClosed = true
+			close(ch)
+		}
+	}
+	drainAudioOut := func() {
+		//nolint:revive // empty body: discarding remaining audio frames is the intent
+		for range audioOut {
+		}
+	}
+	finishTTS := func() {
+		closeTextIn()
+		state.agentSpeaking.Store(false)
+		emit(Event{Type: EventTTSEnded, Timestamp: time.Now()})
+	}
+
+	select {
+	case ch <- text:
+	case <-ctx.Done():
+		closeTextIn()
+		drainAudioOut()
+		finishTTS()
+		return ctx.Err()
+	}
+	closeTextIn()
+
+	for {
+		select {
+		case <-ctx.Done():
+			drainAudioOut()
+			finishTTS()
+			return ctx.Err()
+		case chunk, ok := <-audioOut:
+			if !ok {
+				finishTTS()
+				emit(
+					Event{
+						Type:      EventAssistantDone,
+						Timestamp: time.Now(),
+						Text:      text,
+					},
+				)
+				return nil
+			}
+			if chunk.Error != nil {
+				drainAudioOut()
+				finishTTS()
+				return chunk.Error
+			}
+			if len(chunk.Data) == 0 {
+				continue
+			}
+			select {
+			case ttsAudio <- chunk.Data:
+			case <-ctx.Done():
+				drainAudioOut()
+				finishTTS()
+				return ctx.Err()
+			}
+		}
+	}
+}
+
 // speakOneShot is the fallback path for TTS providers that do not implement
 // tts.StreamingTextProvider. The LLM text is buffered to completion and sent
 // via tts.Generation.StreamAudio.

--- a/voice/runner.go
+++ b/voice/runner.go
@@ -172,6 +172,45 @@ func (c *Conversation) run(
 
 		activeAgent := v
 
+		if v.initialMessage != "" && !historyHasNonSystem(history) {
+			drainAudio(ttsAudio)
+			turnCtx, turnCancel := context.WithCancel(gctx)
+			cancelFn := func() { turnCancel() }
+			state.cancelTurn.Store(&cancelFn)
+			state.setSpoken("")
+			state.dropAudio.Store(false)
+			state.agentSpeaking.Store(false)
+
+			err := speakInitialMessage(
+				turnCtx, v, v.initialMessage, emit, ttsAudio, state,
+			)
+
+			turnCancel()
+			state.cancelTurn.Store(nil)
+
+			switch {
+			case errors.Is(err, context.Canceled) && state.dropAudio.Load():
+				history = append(history, message.NewMessage(
+					message.Assistant,
+					[]message.ContentPart{message.TextContent{
+						Text: v.initialMessage + " [interrupted]",
+					}},
+				))
+			case err != nil && !errors.Is(err, context.Canceled):
+				return err
+			case err == nil:
+				history = append(history, message.NewMessage(
+					message.Assistant,
+					[]message.ContentPart{message.TextContent{
+						Text: v.initialMessage,
+					}},
+				))
+			}
+			if perr := persistNew(); perr != nil {
+				return perr
+			}
+		}
+
 		for {
 			select {
 			case <-gctx.Done():
@@ -320,6 +359,18 @@ func loadInitialHistory(
 		return nil, 0, err
 	}
 	return []message.Message{sysMsg}, 1, nil
+}
+
+// historyHasNonSystem reports whether the message slice contains any
+// non-system message. Used to skip the initial-message greeting when
+// resuming a session that already has user or assistant turns.
+func historyHasNonSystem(h []message.Message) bool {
+	for _, m := range h {
+		if m.Role != message.System {
+			return true
+		}
+	}
+	return false
 }
 
 func drainAudio(ch <-chan []byte) {

--- a/voice/voice.go
+++ b/voice/voice.go
@@ -19,6 +19,7 @@ type Agent struct {
 	stt               stt.SpeechToText
 	tts               tts.Generation
 	systemPrompt      string
+	initialMessage    string
 	tools             []tool.BaseTool
 	toolsets          []tool.Toolset
 	maxToolIterations int

--- a/www/docs/voice/overview.md
+++ b/www/docs/voice/overview.md
@@ -62,6 +62,7 @@ if err := conv.Wait(); err != nil {
 | Option | Description | Default |
 |--------|-------------|---------|
 | `WithSystemPrompt(prompt)` | System prompt prepended to every LLM call | none |
+| `WithInitialMessage(msg)` | Greeting the agent speaks once when a conversation starts (skipped on session resume) | none |
 | `WithTools(tools...)` | Tools the LLM can call during a conversation | none |
 | `WithToolsets(toolsets...)` | `tool.Toolset`s evaluated per LLM call to add dynamic / context-dependent tools to the static set | none |
 | `WithMaxToolIterations(n)` | Cap on tool-call rounds inside one assistant turn | 4 |
@@ -112,6 +113,24 @@ type AudioTransport interface {
 | `EventAgentInterrupted` | Barge-in fired and the current turn was canceled | `Text` (spoken-so-far approximation) |
 | `EventConversationEnd` | The pipeline goroutines have all returned | (none) |
 | `EventError` | An unrecoverable error terminated the conversation | `Error` |
+
+## Initial message
+
+`WithInitialMessage` lets the agent speak first when a conversation opens — useful for greetings, prompts, or whatever you'd put in `first_message` on ElevenLabs ConvAI.
+
+```go
+voice.WithInitialMessage("Hi, how can I help you today?")
+```
+
+**Behavior:**
+
+- Fires once, right after `EventReady`, before the runner waits for the first user transcript.
+- Skipped when resuming a session whose stored history already contains user or assistant messages — a mid-thread greeting would be wrong.
+- No LLM call. The configured text is sent straight to TTS, then appended to history (and persisted via `WithSession` if configured).
+- Participates in barge-in. Under `BargeInInterrupt`, a user partial during the greeting cancels TTS, fires `EventAgentInterrupted`, and records the history entry as `<text> [interrupted]`.
+- Uses the streaming TTS path when the client implements `tts.StreamingTextProvider`; falls back to single-shot `tts.Generation.StreamAudio` otherwise.
+
+For dynamic, per-conversation greetings (e.g. addressing the user by name), keep this option empty and have your first user turn driven by the conversation initiation flow — that's a separate slice.
 
 ## Filler audio
 


### PR DESCRIPTION
This pull request adds support for an initial greeting message that the voice agent can speak once at the start of a new conversation. The greeting is configurable, skipped on session resume, and integrates with barge-in and TTS fallback mechanisms. The changes also include comprehensive tests and documentation updates.