### PR TITLE
update makefile, most recent golines which is up to date as the origi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 install:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install github.com/segmentio/golines@latest
+	go install github.com/golangci/golines@latest
 
 workspace:
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
…nal tool is archived and not mentained anymore
[golines](https://github.com/segmentio/golines) is no longer maintained and it's recommended to user most recent updated version, with updated dependencies. 