### PR TITLE
chore: bump model dep to v0.2.0 in gemini modules

### DIFF
--- a/batch/gemini/go.mod
+++ b/batch/gemini/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/joakimcarlsson/ai/embeddings v0.1.0
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.0
 	google.golang.org/genai v1.55.0
 )

--- a/embeddings/gemini/go.mod
+++ b/embeddings/gemini/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/embeddings v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.2.0
 	google.golang.org/genai v1.55.0
 )
 

--- a/image/gemini/go.mod
+++ b/image/gemini/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/image v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.2.0
 	google.golang.org/genai v1.55.0
 )
 

--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.2.0
 	github.com/joakimcarlsson/ai/schema v0.1.0
 	github.com/joakimcarlsson/ai/tool v0.1.0
 	github.com/joakimcarlsson/ai/types v0.1.0

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/llm/gemini v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.2.0
 	google.golang.org/genai v1.55.0
 )
 


### PR DESCRIPTION
## Summary

Cascades [`model/v0.2.0`](https://github.com/JoakimCarlsson/ai/tree/model/v0.2.0) (new Gemini 3.5 / 3.1 / 2.5 model IDs, Nano Banana 2, `GeminiEmbedding2`, refreshed pricing) to the modules a typical user pulls to access them. After this, ``go get <module>@latest`` resolves ``model@v0.2.0`` via MVS — no explicit ``go get model@v0.2.0`` needed.

Affected:

- ``llm/gemini``
- ``image/gemini``
- ``embeddings/gemini``
- ``batch/gemini``
- ``llm/vertexai``

Each is a single-line ``require`` bump from ``model v0.1.0`` to ``v0.2.0``. No source changes; ``go build ./...`` passes for all five.

Non-Gemini modules (``llm/openai``, ``llm/anthropic``, ``agent``, ``voice``, etc.) intentionally untouched — they don't reference any ``model.Gemini*`` constants, and a user wanting Gemini already pulls one of the modules above directly. Matches the precedent set by ``release-2026-05-10`` (cascade only to direct consumers, not the whole tree).

## Test plan

- [x] ``go build ./...`` in each of the 5 modules
- [ ] CI green