### PR TITLE
chore: cascade embeddings@v0.2.0 to provider modules

### DIFF
--- a/embeddings/bedrock/go.mod
+++ b/embeddings/bedrock/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6
-	github.com/joakimcarlsson/ai/embeddings v0.1.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 )
 

--- a/embeddings/cohere/go.mod
+++ b/embeddings/cohere/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/cohere
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.1.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 )
 

--- a/embeddings/gemini/go.mod
+++ b/embeddings/gemini/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/gemini
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.1.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.0
 	github.com/joakimcarlsson/ai/model v0.2.0
 	google.golang.org/genai v1.55.0
 )

--- a/embeddings/mistral/go.mod
+++ b/embeddings/mistral/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.1.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 )
 

--- a/embeddings/openai/go.mod
+++ b/embeddings/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.1.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 	github.com/openai/openai-go v1.12.0
 )

--- a/embeddings/openai/go.sum
+++ b/embeddings/openai/go.sum
@@ -25,6 +25,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/embeddings/voyage/go.mod
+++ b/embeddings/voyage/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/voyage
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.1.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 )
 


### PR DESCRIPTION
## Summary

Cascade the `embeddings/v0.2.0` minor bump (new `MultimodalContent.MimeType` / `ContentData` fields from #156) into every direct embeddings provider module so `go get embeddings/<provider>@latest` resolves the new fields via MVS.

Bumps `require github.com/joakimcarlsson/ai/embeddings` to `v0.2.0` in:
- `embeddings/bedrock`
- `embeddings/cohere`
- `embeddings/gemini`
- `embeddings/mistral`
- `embeddings/openai`
- `embeddings/voyage`

Skips umbrella consumers (`agent`, `voice`, `batch/*`, `memory/*`) per the cascade rule in README.

## Test plan

- [x] `go build ./...` clean in each cascaded module
- [x] `go mod tidy` produced no churn beyond the require bump (one `go.sum` line in `embeddings/openai`)
- [ ] CI green on PR

## Follow-up tags after merge

- `embeddings/bedrock/v0.1.1`, `embeddings/cohere/v0.1.1`, `embeddings/mistral/v0.1.1`, `embeddings/openai/v0.1.1`, `embeddings/voyage/v0.1.1` (require-only patch)
- `embeddings/gemini/v0.2.0` (require bump + new multimodal impl from #156)