### PR TITLE
chore: cascade stt@v0.2.0 to assemblyai and deepgram

### DIFF
--- a/stt/assemblyai/go.mod
+++ b/stt/assemblyai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.1.0
-	github.com/joakimcarlsson/ai/stt v0.1.0
+	github.com/joakimcarlsson/ai/stt v0.2.0
 )
 
 require (

--- a/stt/deepgram/go.mod
+++ b/stt/deepgram/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.1.0
-	github.com/joakimcarlsson/ai/stt v0.1.0
+	github.com/joakimcarlsson/ai/stt v0.2.0
 )
 
 require (


### PR DESCRIPTION
## Summary
- Bump `stt` dep to `v0.2.0` in `stt/assemblyai` and `stt/deepgram`
- Cascade so consumers running `go get <module>@latest` pick up the new `Speaker` field on `Word` and `StreamResult` (added in [#161](https://github.com/JoakimCarlsson/ai/pull/161))

Without this cascade, `go get stt/assemblyai@latest` would resolve `stt v0.1.0` (which lacks `Speaker`) and break consumer builds.

## Test plan
- [x] `GOWORK=off go build .` in `stt/assemblyai` — passes
- [x] `GOWORK=off go build .` in `stt/deepgram` — passes