### PR TITLE
chore: cascade model@v0.3.0 to anthropic and openrouter consumers

### DIFF
--- a/batch/anthropic/go.mod
+++ b/batch/anthropic/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/joakimcarlsson/ai/batch v0.1.0
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.3.0
 	github.com/joakimcarlsson/ai/tool v0.1.0
 )
 

--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.46.0
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.3.0
 	github.com/joakimcarlsson/ai/schema v0.1.0
 	github.com/joakimcarlsson/ai/tool v0.1.0
 	github.com/joakimcarlsson/ai/types v0.1.0

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/joakimcarlsson/ai/message v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.1.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect


### PR DESCRIPTION
`model@v0.3.0` adds the `Claude48Opus` and `OpenRouterClaude48Opus` constants (Claude 4.8 Opus support).

This bumps the `require github.com/joakimcarlsson/ai/model` line from `v0.1.0` to `v0.3.0` in the modules a user `go get`s to reach those symbols, so MVS resolves `model@v0.3.0` instead of the old floor:

- `llm/anthropic`
- `batch/anthropic`
- `llm/openrouter`

No code changes; `go.sum` is unaffected (local replace directive, no hash needed). Each module builds clean with `GOWORK=off go build ./...`.

Follow-up after merge: tag `llm/anthropic/v0.2.2`, `batch/anthropic/v0.1.1`, `llm/openrouter/v0.2.1`.