### PR TITLE
chore: cascade upgraded SDKs into wrapper modules

### DIFF
--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/anthropic v0.1.0
+	github.com/joakimcarlsson/ai/llm/anthropic v0.2.2
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.3.0
 	github.com/joakimcarlsson/ai/schema v0.1.0
 	github.com/joakimcarlsson/ai/tool v0.1.0
 	github.com/joakimcarlsson/ai/types v0.1.0

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/llm/openai v0.3.2
 )
 
 require (


### PR DESCRIPTION
Follow-up to #167. The OpenAI-compatible wrappers pinned `llm/openai@v0.2.0` and `bedrock` pinned `llm/anthropic@v0.1.0`, so their consumers resolved the **old** vendor SDKs (`openai-go v3.35.0`, `anthropic-sdk-go v1.38.0`) via MVS regardless of the upgrades that landed in the base modules.

This bumps the base `require` so consumers pick up the new SDKs:

- `require llm/openai@v0.3.2` → `cerebras`, `deepseek`, `fireworks`, `mistral`, `ollama`, `perplexity`, `together`, `openrouter` (now ship `openai-go v3.37.0`)
- `require llm/anthropic@v0.2.2` → `bedrock` (now ships `anthropic-sdk-go v1.46.0`, and inherits `model@v0.3.0` / Claude 4.8 Opus transitively)

The dual-carrier modules (`azure`, `groq`, `xai`, `vertexai`) already ship the new SDK via their direct `require`, so they are untouched here.

All nine build clean with `GOWORK=off go build ./...`.

Follow-up after merge: tag `cerebras/deepseek/fireworks/mistral/ollama/perplexity/together v0.2.1`, `openrouter v0.2.2`, `bedrock v0.1.1`.