### PR TITLE
Task/171 fix incorrect llm request parameter handling top k dropped stop truncated bedrock caching forced off

### DIFF
--- a/llm/bedrock/bedrock.go
+++ b/llm/bedrock/bedrock.go
@@ -33,6 +33,7 @@ type Options struct {
 	topK          *int64
 	stopSequences []string
 	timeout       *time.Duration
+	disableCache  bool
 }
 
 // Option configures Options.
@@ -81,6 +82,11 @@ func WithTimeout(
 ) Option {
 	return func(o *Options) { o.timeout = &timeout }
 }
+
+// WithDisableCache disables Anthropic prompt caching. Caching is enabled by
+// default; when enabled, cache_control breakpoints emitted by the underlying
+// Anthropic client reach Bedrock and produce cacheRead/cacheWrite token usage.
+func WithDisableCache() Option { return func(o *Options) { o.disableCache = true } }
 
 // Client implements [llm.LLM] against AWS Bedrock by delegating to a child
 // vendor client (Anthropic for Claude on Bedrock).
@@ -138,7 +144,9 @@ func newAnthropicChild(options Options) llm.LLM {
 		llmanthropic.WithModel(options.model),
 		llmanthropic.WithMaxTokens(options.maxTokens),
 		llmanthropic.WithBedrock(true),
-		llmanthropic.WithDisableCache(),
+	}
+	if options.disableCache {
+		anthOpts = append(anthOpts, llmanthropic.WithDisableCache())
 	}
 	if options.apiKey != "" {
 		anthOpts = append(anthOpts, llmanthropic.WithAPIKey(options.apiKey))

--- a/llm/bedrock/bedrock_test.go
+++ b/llm/bedrock/bedrock_test.go
@@ -1,0 +1,27 @@
+package bedrock
+
+import "testing"
+
+func applyOptions(opts ...Option) Options {
+	var o Options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// TestCachingEnabledByDefault verifies that prompt caching is no longer forced
+// off: a freshly configured client leaves disableCache false so cache_control
+// breakpoints reach Bedrock.
+func TestCachingEnabledByDefault(t *testing.T) {
+	if applyOptions().disableCache {
+		t.Fatal("expected caching enabled by default (disableCache=false)")
+	}
+}
+
+// TestWithDisableCacheRespected verifies that callers can still opt out.
+func TestWithDisableCacheRespected(t *testing.T) {
+	if !applyOptions(WithDisableCache()).disableCache {
+		t.Fatal("expected WithDisableCache() to set disableCache=true")
+	}
+}

--- a/llm/groq/compound.go
+++ b/llm/groq/compound.go
@@ -280,7 +280,7 @@ func (c *compoundClient) preparedParams(
 	}
 	if len(c.options.stopSequences) > 0 {
 		params.Stop = openaisdk.ChatCompletionNewParamsStopUnion{
-			OfString: openaisdk.String(c.options.stopSequences[0]),
+			OfStringArray: c.options.stopSequences,
 		}
 	}
 	return params

--- a/llm/groq/compound.go
+++ b/llm/groq/compound.go
@@ -279,8 +279,12 @@ func (c *compoundClient) preparedParams(
 		params.TopP = openaisdk.Float(*c.options.topP)
 	}
 	if len(c.options.stopSequences) > 0 {
+		stops := c.options.stopSequences
+		if len(stops) > 4 {
+			stops = stops[:4]
+		}
 		params.Stop = openaisdk.ChatCompletionNewParamsStopUnion{
-			OfStringArray: c.options.stopSequences,
+			OfStringArray: stops,
 		}
 	}
 	return params

--- a/llm/groq/compound_test.go
+++ b/llm/groq/compound_test.go
@@ -1,0 +1,42 @@
+package groq
+
+import (
+	"testing"
+
+	openaisdk "github.com/openai/openai-go/v3"
+)
+
+// TestCompoundPreparedParamsStopSequencesArray verifies that the Groq compound
+// client sends every provided stop sequence as an array, not just the first.
+func TestCompoundPreparedParamsStopSequencesArray(t *testing.T) {
+	c := &compoundClient{options: CompoundOptions{
+		stopSequences: []string{"END", "STOP", "HALT"},
+	}}
+
+	params := c.preparedParams(
+		[]openaisdk.ChatCompletionMessageParamUnion{},
+		nil,
+	)
+
+	if params.Stop.OfString.Valid() {
+		t.Fatalf(
+			"expected OfString to be unset, got %q",
+			params.Stop.OfString.Value,
+		)
+	}
+	got := params.Stop.OfStringArray
+	want := []string{"END", "STOP", "HALT"}
+	if len(got) != len(want) {
+		t.Fatalf(
+			"expected %d stop sequences, got %d: %v",
+			len(want),
+			len(got),
+			got,
+		)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("stop[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/llm/groq/compound_test.go
+++ b/llm/groq/compound_test.go
@@ -40,3 +40,24 @@ func TestCompoundPreparedParamsStopSequencesArray(t *testing.T) {
 		}
 	}
 }
+
+// TestCompoundPreparedParamsStopSequencesCappedAtFour verifies the Groq stop
+// limit of 4 is enforced, matching OpenAI.
+func TestCompoundPreparedParamsStopSequencesCappedAtFour(t *testing.T) {
+	c := &compoundClient{options: CompoundOptions{
+		stopSequences: []string{"1", "2", "3", "4", "5", "6"},
+	}}
+
+	params := c.preparedParams(
+		[]openaisdk.ChatCompletionMessageParamUnion{},
+		nil,
+	)
+
+	if len(params.Stop.OfStringArray) != 4 {
+		t.Fatalf(
+			"expected stop sequences capped at 4, got %d: %v",
+			len(params.Stop.OfStringArray),
+			params.Stop.OfStringArray,
+		)
+	}
+}

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -84,7 +84,10 @@ func WithTemperature(
 // WithTopP sets nucleus sampling probability mass.
 func WithTopP(p float64) Option { return func(o *Options) { o.topP = &p } }
 
-// WithTopK limits token selection to the top K candidates.
+// WithTopK limits token selection to the top K candidates. OpenAI and Azure
+// reject top_k, so it is sent only when a custom base URL targets an
+// OpenAI-compatible provider that accepts it (Together, OpenRouter, Fireworks,
+// ...); otherwise it has no effect. See requestOptions.
 func WithTopK(k int64) Option { return func(o *Options) { o.topK = &k } }
 
 // WithStopSequences sets text sequences that halt generation.
@@ -396,7 +399,9 @@ func (c *Client) preparedParams(
 	pb := llm.NewParameterBuilder(
 		c.options.temperature,
 		c.options.topP,
-		c.options.topK,
+		// top_k has no native field on ChatCompletionNewParams; it is injected
+		// into the request body by requestOptions instead.
+		nil,
 	)
 	pb.ApplyFloat64Temperature(
 		func(t *float64) { params.Temperature = openaisdk.Float(*t) },
@@ -404,8 +409,13 @@ func (c *Client) preparedParams(
 	pb.ApplyFloat64TopP(func(p *float64) { params.TopP = openaisdk.Float(*p) })
 
 	if len(c.options.stopSequences) > 0 {
+		// The OpenAI API accepts up to 4 stop sequences as an array.
+		stops := c.options.stopSequences
+		if len(stops) > 4 {
+			stops = stops[:4]
+		}
 		params.Stop = openaisdk.ChatCompletionNewParamsStopUnion{
-			OfString: openaisdk.String(c.options.stopSequences[0]),
+			OfStringArray: stops,
 		}
 	}
 
@@ -433,6 +443,22 @@ func (c *Client) preparedParams(
 	return params
 }
 
+// requestOptions returns per-call SDK request options derived from Options.
+//
+// The OpenAI Go SDK has no native top_k field on ChatCompletionNewParams. When
+// WithTopK is set, the value is injected directly into the request body, but
+// only on the OpenAI-compatible path (when a custom base URL is configured):
+// OpenAI's and Azure's own APIs reject top_k as an unrecognized argument
+// (HTTP 400), whereas compatible providers that accept it — Together,
+// OpenRouter, Fireworks, ... — honor it. Without a custom base URL the target
+// is OpenAI/Azure proper, so top_k is omitted rather than triggering a 400.
+func (c *Client) requestOptions() []option.RequestOption {
+	if c.options.topK == nil || c.options.baseURL == "" {
+		return nil
+	}
+	return []option.RequestOption{option.WithJSONSet("top_k", *c.options.topK)}
+}
+
 // SendMessages sends a conversation and returns the complete response.
 func (c *Client) SendMessages(
 	ctx context.Context,
@@ -451,7 +477,10 @@ func (c *Client) SendMessages(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
-			openaiResponse, err := c.client.Chat.Completions.New(ctx, params)
+			openaiResponse, err := c.client.Chat.Completions.New(
+				ctx,
+				params,
+				c.requestOptions()...)
 			if err != nil {
 				return nil, wrapError(err)
 			}
@@ -516,7 +545,10 @@ func (c *Client) runStream(
 	eventChan chan<- llm.Event,
 	structured bool,
 ) error {
-	openaiStream := c.client.Chat.Completions.NewStreaming(ctx, params)
+	openaiStream := c.client.Chat.Completions.NewStreaming(
+		ctx,
+		params,
+		c.requestOptions()...)
 
 	acc := openaisdk.ChatCompletionAccumulator{}
 	currentContent := ""
@@ -656,7 +688,10 @@ func (c *Client) SendMessagesWithStructuredOutput(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
-			openaiResponse, err := c.client.Chat.Completions.New(ctx, params)
+			openaiResponse, err := c.client.Chat.Completions.New(
+				ctx,
+				params,
+				c.requestOptions()...)
 			if err != nil {
 				return nil, wrapError(err)
 			}

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -399,8 +399,6 @@ func (c *Client) preparedParams(
 	pb := llm.NewParameterBuilder(
 		c.options.temperature,
 		c.options.topP,
-		// top_k has no native field on ChatCompletionNewParams; it is injected
-		// into the request body by requestOptions instead.
 		nil,
 	)
 	pb.ApplyFloat64Temperature(
@@ -409,7 +407,6 @@ func (c *Client) preparedParams(
 	pb.ApplyFloat64TopP(func(p *float64) { params.TopP = openaisdk.Float(*p) })
 
 	if len(c.options.stopSequences) > 0 {
-		// The OpenAI API accepts up to 4 stop sequences as an array.
 		stops := c.options.stopSequences
 		if len(stops) > 4 {
 			stops = stops[:4]

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -1,0 +1,144 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+// TestPreparedParamsStopSequencesArray verifies that all provided stop
+// sequences are sent as an array (OfStringArray), not just the first one.
+func TestPreparedParamsStopSequencesArray(t *testing.T) {
+	c := &Client{options: Options{
+		stopSequences: []string{"END", "STOP", "HALT"},
+	}}
+
+	params := c.preparedParams(nil, nil)
+
+	if params.Stop.OfString.Valid() {
+		t.Fatalf(
+			"expected OfString to be unset, got %q",
+			params.Stop.OfString.Value,
+		)
+	}
+	got := params.Stop.OfStringArray
+	want := []string{"END", "STOP", "HALT"}
+	if len(got) != len(want) {
+		t.Fatalf(
+			"expected %d stop sequences, got %d: %v",
+			len(want),
+			len(got),
+			got,
+		)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("stop[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestPreparedParamsStopSequencesCappedAtFour verifies that the OpenAI-native
+// limit of 4 stop sequences is enforced.
+func TestPreparedParamsStopSequencesCappedAtFour(t *testing.T) {
+	c := &Client{options: Options{
+		stopSequences: []string{"1", "2", "3", "4", "5", "6"},
+	}}
+
+	params := c.preparedParams(nil, nil)
+
+	if len(params.Stop.OfStringArray) != 4 {
+		t.Fatalf("expected stop sequences capped at 4, got %d: %v",
+			len(params.Stop.OfStringArray), params.Stop.OfStringArray)
+	}
+}
+
+// TestRequestOptionsTopK verifies that top_k yields a request option only on
+// the compatible-provider path: it requires both WithTopK and a custom base
+// URL, since OpenAI/Azure proper reject top_k.
+func TestRequestOptionsTopK(t *testing.T) {
+	k := int64(40)
+
+	none := (&Client{options: Options{baseURL: "https://example.test"}}).requestOptions()
+	if len(none) != 0 {
+		t.Errorf(
+			"expected no request options when top_k unset, got %d",
+			len(none),
+		)
+	}
+
+	native := (&Client{options: Options{topK: &k}}).requestOptions()
+	if len(native) != 0 {
+		t.Errorf("expected no top_k injection without a custom base URL "+
+			"(OpenAI/Azure reject it), got %d", len(native))
+	}
+
+	compat := (&Client{options: Options{topK: &k, baseURL: "https://example.test"}}).requestOptions()
+	if len(compat) != 1 {
+		t.Fatalf(
+			"expected one request option on the compatible path, got %d",
+			len(compat),
+		)
+	}
+}
+
+// TestWireTopKAndStop confirms that top_k reaches the request body and that all
+// stop sequences are serialized as a JSON array on the wire.
+func TestWireTopKAndStop(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion",`+
+				`"choices":[{"index":0,"message":{"role":"assistant",`+
+				`"content":"hi"},"finish_reason":"stop"}],`+
+				`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+		}))
+	defer srv.Close()
+
+	llm := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithTopK(40),
+		WithStopSequences("END", "STOP", "HALT"),
+	)
+
+	_, err := llm.SendMessages(
+		context.Background(),
+		[]message.Message{message.NewUserMessage("hello")},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if got, ok := body["top_k"].(float64); !ok || int64(got) != 40 {
+		t.Errorf("expected top_k=40 in request body, got %v (%T)",
+			body["top_k"], body["top_k"])
+	}
+
+	stop, ok := body["stop"].([]any)
+	if !ok {
+		t.Fatalf("expected stop to be a JSON array, got %v (%T)",
+			body["stop"], body["stop"])
+	}
+	want := []string{"END", "STOP", "HALT"}
+	if len(stop) != len(want) {
+		t.Fatalf("expected %d stop sequences on the wire, got %d: %v",
+			len(want), len(stop), stop)
+	}
+	for i, v := range want {
+		if stop[i] != v {
+			t.Errorf("wire stop[%d] = %v, want %q", i, stop[i], v)
+		}
+	}
+}

--- a/www/docs/providers/llm.md
+++ b/www/docs/providers/llm.md
@@ -93,6 +93,14 @@ llmopenai.WithStopSequences("STOP", "END")
 llmopenai.WithTimeout(30 * time.Second)
 ```
 
+!!! note "`WithTopK` on the OpenAI client"
+    OpenAI's and Azure's own APIs reject `top_k` (HTTP 400), so `llmopenai.WithTopK`
+    is sent only when a custom base URL points at an OpenAI-compatible provider that
+    accepts it (Together, OpenRouter, Fireworks, ...); against OpenAI or Azure proper
+    it has no effect. Native providers (Anthropic, Gemini, Bedrock) honor `WithTopK`
+    directly. `WithStopSequences` sends every sequence provided (the OpenAI client
+    caps at the API's limit of 4).
+
 ## Vendor-specific options
 
 OpenAI:
@@ -243,6 +251,12 @@ client := llmbedrock.NewLLM(
     llmbedrock.WithMaxTokens(2000),
 )
 ```
+
+Prompt caching is on by default on Bedrock: the underlying Anthropic client's
+`cache_control` breakpoints reach Bedrock and populate `CacheReadTokens` /
+`CacheCreationTokens` in the response usage. Pass `llmbedrock.WithDisableCache()`
+to opt out. (Newer Claude models require at least 4096 cached tokens per
+checkpoint before a cache hit is recorded.)
 
 ```go
 import llmvertex "github.com/joakimcarlsson/ai/llm/vertexai"


### PR DESCRIPTION
closes #171 

This pull request introduces several improvements and bug fixes to the LLM provider clients, with a focus on OpenAI, Bedrock (Anthropic), and Groq integrations. The most notable changes ensure correct handling of stop sequences, clarify and enforce provider-specific option behaviors (such as `top_k`), and add comprehensive tests and documentation updates to support these behaviors.