### PR TITLE
Task/172 surface verified provider native capabilities deepseek cache tokens gemini thinking budget openrouter routing perplexity search reasoning tokens

### DIFF
--- a/llm/deepseek/deepseek.go
+++ b/llm/deepseek/deepseek.go
@@ -3,6 +3,11 @@
 // This is a thin wrapper over [llm/openai] fixed to DeepSeek's chat-completions
 // endpoint. DeepSeek's reasoning_content streaming field is surfaced through
 // the openai package's existing thinking-delta event handling.
+//
+// DeepSeek reports cache usage as top-level usage fields rather than in
+// prompt_tokens_details; the openai client reads prompt_cache_hit_tokens into
+// [llm.TokenUsage].CacheReadTokens and completion_tokens_details.reasoning_tokens
+// into [llm.TokenUsage].ReasoningTokens, so no DeepSeek-specific wiring is needed.
 package deepseek
 
 import (

--- a/llm/deepseek/deepseek_test.go
+++ b/llm/deepseek/deepseek_test.go
@@ -18,7 +18,7 @@ import (
 // and ReasoningTokens (from completion_tokens_details).
 func TestCacheHitTokens(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
+		func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion",`+
 				`"choices":[{"index":0,"message":{"role":"assistant",`+

--- a/llm/deepseek/deepseek_test.go
+++ b/llm/deepseek/deepseek_test.go
@@ -1,0 +1,54 @@
+package deepseek_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm/deepseek"
+	llmopenai "github.com/joakimcarlsson/ai/llm/openai"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+// TestCacheHitTokens verifies a DeepSeek response with a cache hit populates
+// CacheReadTokens (read from the top-level prompt_cache_hit_tokens usage field)
+// and ReasoningTokens (from completion_tokens_details).
+func TestCacheHitTokens(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion",`+
+				`"choices":[{"index":0,"message":{"role":"assistant",`+
+				`"content":"hi"},"finish_reason":"stop"}],`+
+				`"usage":{"prompt_tokens":100,"completion_tokens":40,`+
+				`"total_tokens":140,"prompt_cache_hit_tokens":80,`+
+				`"prompt_cache_miss_tokens":20,`+
+				`"completion_tokens_details":{"reasoning_tokens":15}}}`)
+		}))
+	defer srv.Close()
+
+	client := deepseek.NewLLM(
+		llmopenai.WithAPIKey("test-key"),
+		llmopenai.WithBaseURL(srv.URL),
+		llmopenai.WithModel(model.Model{APIModel: "deepseek-chat"}),
+	)
+
+	resp, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if resp.Usage.CacheReadTokens != 80 {
+		t.Errorf("CacheReadTokens = %d, want 80", resp.Usage.CacheReadTokens)
+	}
+	if resp.Usage.InputTokens != 20 {
+		t.Errorf("InputTokens = %d, want 20", resp.Usage.InputTokens)
+	}
+	if resp.Usage.ReasoningTokens != 15 {
+		t.Errorf("ReasoningTokens = %d, want 15", resp.Usage.ReasoningTokens)
+	}
+}

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -5,6 +5,8 @@ go 1.25.0
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/message v0.1.0
+	github.com/joakimcarlsson/ai/model v0.1.0
 )
 
 require (
@@ -15,8 +17,6 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect

--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -47,6 +47,7 @@ type Options struct {
 	presencePenalty  *float64
 	seed             *int64
 	thinkingLevel    *ThinkingLevel
+	thinkingBudget   *int32
 	builtinTools     []*genai.Tool
 }
 
@@ -120,6 +121,17 @@ func WithSeed(seed int64) Option { return func(o *Options) { o.seed = &seed } }
 // WithThinkingLevel sets the thinking level for Gemini models that support reasoning.
 func WithThinkingLevel(level ThinkingLevel) Option {
 	return func(o *Options) { o.thinkingLevel = &level }
+}
+
+// WithThinkingBudget sets the Gemini 2.5 thinking budget in tokens via
+// thinkingConfig.thinkingBudget: -1 lets the model decide dynamically, 0
+// disables thinking, and a positive value caps the reasoning tokens. It applies
+// only to models that can reason and can be combined with WithThinkingLevel.
+func WithThinkingBudget(tokens int) Option {
+	return func(o *Options) {
+		b := int32(tokens)
+		o.thinkingBudget = &b
+	}
 }
 
 // WithGoogleSearch enables Gemini's built-in Google Search grounding tool.
@@ -326,19 +338,27 @@ func (c *Client) finishReason(reason genai.FinishReason) message.FinishReason {
 }
 
 func (c *Client) applyThinkingConfig(config *genai.GenerateContentConfig) {
-	if c.options.thinkingLevel == nil || !c.options.model.CanReason {
+	if !c.options.model.CanReason {
+		return
+	}
+	if c.options.thinkingLevel == nil && c.options.thinkingBudget == nil {
 		return
 	}
 	tc := &genai.ThinkingConfig{IncludeThoughts: true}
-	switch *c.options.thinkingLevel {
-	case ThinkingLevelMinimal:
-		tc.ThinkingLevel = genai.ThinkingLevelMinimal
-	case ThinkingLevelLow:
-		tc.ThinkingLevel = genai.ThinkingLevelLow
-	case ThinkingLevelMedium:
-		tc.ThinkingLevel = genai.ThinkingLevelMedium
-	case ThinkingLevelHigh:
-		tc.ThinkingLevel = genai.ThinkingLevelHigh
+	if c.options.thinkingLevel != nil {
+		switch *c.options.thinkingLevel {
+		case ThinkingLevelMinimal:
+			tc.ThinkingLevel = genai.ThinkingLevelMinimal
+		case ThinkingLevelLow:
+			tc.ThinkingLevel = genai.ThinkingLevelLow
+		case ThinkingLevelMedium:
+			tc.ThinkingLevel = genai.ThinkingLevelMedium
+		case ThinkingLevelHigh:
+			tc.ThinkingLevel = genai.ThinkingLevelHigh
+		}
+	}
+	if c.options.thinkingBudget != nil {
+		tc.ThinkingBudget = c.options.thinkingBudget
 	}
 	config.ThinkingConfig = tc
 }
@@ -795,6 +815,7 @@ func (c *Client) usage(resp *genai.GenerateContentResponse) llm.TokenUsage {
 		OutputTokens:        int64(resp.UsageMetadata.CandidatesTokenCount),
 		CacheCreationTokens: 0,
 		CacheReadTokens:     int64(resp.UsageMetadata.CachedContentTokenCount),
+		ReasoningTokens:     int64(resp.UsageMetadata.ThoughtsTokenCount),
 	}
 }
 

--- a/llm/gemini/gemini_test.go
+++ b/llm/gemini/gemini_test.go
@@ -1,0 +1,69 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/joakimcarlsson/ai/model"
+)
+
+func reasoningClient(opts ...Option) *Client {
+	o := Options{model: model.Model{CanReason: true}}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Client{options: o}
+}
+
+// TestThinkingBudgetSetsConfig verifies WithThinkingBudget populates
+// ThinkingConfig.ThinkingBudget on the built config.
+func TestThinkingBudgetSetsConfig(t *testing.T) {
+	cfg := reasoningClient(WithThinkingBudget(2048)).buildConfig(nil, nil)
+	if cfg.ThinkingConfig == nil {
+		t.Fatal("expected ThinkingConfig to be set")
+	}
+	if cfg.ThinkingConfig.ThinkingBudget == nil {
+		t.Fatal("expected ThinkingBudget to be set")
+	}
+	if got := *cfg.ThinkingConfig.ThinkingBudget; got != 2048 {
+		t.Errorf("ThinkingBudget = %d, want 2048", got)
+	}
+}
+
+// TestThinkingBudgetZeroDisables verifies a budget of 0 is sent as an explicit
+// 0 (disable thinking), not omitted.
+func TestThinkingBudgetZeroDisables(t *testing.T) {
+	cfg := reasoningClient(WithThinkingBudget(0)).buildConfig(nil, nil)
+	if cfg.ThinkingConfig == nil || cfg.ThinkingConfig.ThinkingBudget == nil {
+		t.Fatal("expected ThinkingBudget to be set to 0")
+	}
+	if got := *cfg.ThinkingConfig.ThinkingBudget; got != 0 {
+		t.Errorf("ThinkingBudget = %d, want 0", got)
+	}
+}
+
+// TestThinkingLevelStillWorks verifies the named-level option keeps mapping to
+// the SDK ThinkingLevel and combines with a budget.
+func TestThinkingLevelStillWorks(t *testing.T) {
+	cfg := reasoningClient(WithThinkingLevel(ThinkingLevelHigh)).
+		buildConfig(nil, nil)
+	if cfg.ThinkingConfig == nil {
+		t.Fatal("expected ThinkingConfig to be set")
+	}
+	if cfg.ThinkingConfig.ThinkingLevel == "" {
+		t.Error("expected ThinkingLevel to be set")
+	}
+	if cfg.ThinkingConfig.ThinkingBudget != nil {
+		t.Error("expected ThinkingBudget to remain unset")
+	}
+}
+
+// TestThinkingDisabledWithoutReasoning verifies no thinking config leaks onto a
+// model that cannot reason.
+func TestThinkingDisabledWithoutReasoning(t *testing.T) {
+	c := &Client{options: Options{model: model.Model{CanReason: false}}}
+	WithThinkingBudget(1024)(&c.options)
+	cfg := c.buildConfig(nil, nil)
+	if cfg.ThinkingConfig != nil {
+		t.Error("expected no ThinkingConfig when model cannot reason")
+	}
+}

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -101,6 +101,10 @@ type TokenUsage struct {
 	OutputTokens        int64
 	CacheCreationTokens int64
 	CacheReadTokens     int64
+	// ReasoningTokens counts tokens spent on internal reasoning/thinking, as
+	// reported by providers that surface it (OpenAI o-series, Gemini, DeepSeek).
+	// These are billed within OutputTokens, not in addition to them.
+	ReasoningTokens int64
 }
 
 // Add accumulates token counts from another TokenUsage into this one.
@@ -109,6 +113,7 @@ func (u *TokenUsage) Add(other TokenUsage) {
 	u.OutputTokens += other.OutputTokens
 	u.CacheCreationTokens += other.CacheCreationTokens
 	u.CacheReadTokens += other.CacheReadTokens
+	u.ReasoningTokens += other.ReasoningTokens
 }
 
 // Response represents the complete response from an LLM provider.

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -52,6 +52,8 @@ type Options struct {
 	presencePenalty   *float64
 	seed              *int64
 	parallelToolCalls *bool
+	extraBodyFields   map[string]any
+	metadataFields    map[string]string
 }
 
 // Option configures Options.
@@ -144,6 +146,35 @@ func WithSeed(seed int64) Option { return func(o *Options) { o.seed = &seed } }
 // WithParallelToolCalls toggles whether OpenAI returns multiple tool calls in a single response.
 func WithParallelToolCalls(enabled bool) Option {
 	return func(o *Options) { o.parallelToolCalls = &enabled }
+}
+
+// WithRequestJSONField injects an arbitrary top-level field into the request
+// body via the SDK's WithJSONSet. It is the shared mechanism OpenAI-compatible
+// providers (OpenRouter, Perplexity, ...) use to express vendor features that
+// are absent from the OpenAI wire schema, such as a provider routing object or
+// search filters. Like WithTopK, injected fields are only meaningful when a
+// custom base URL targets a provider that accepts them.
+func WithRequestJSONField(key string, value any) Option {
+	return func(o *Options) {
+		if o.extraBodyFields == nil {
+			o.extraBodyFields = make(map[string]any)
+		}
+		o.extraBodyFields[key] = value
+	}
+}
+
+// WithResponseMetadataField surfaces a top-level response field into
+// [llm.Response].ProviderMetadata. responseField is read from the completion's
+// JSON extra fields (fields the OpenAI SDK does not model natively, such as
+// Perplexity's citations) and stored under metaKey, which callers should
+// namespace per provider (e.g. "perplexity.citations").
+func WithResponseMetadataField(responseField, metaKey string) Option {
+	return func(o *Options) {
+		if o.metadataFields == nil {
+			o.metadataFields = make(map[string]string)
+		}
+		o.metadataFields[responseField] = metaKey
+	}
 }
 
 // RetryConfig provides retry settings tuned for OpenAI API behavior.
@@ -450,10 +481,14 @@ func (c *Client) preparedParams(
 // OpenRouter, Fireworks, ... — honor it. Without a custom base URL the target
 // is OpenAI/Azure proper, so top_k is omitted rather than triggering a 400.
 func (c *Client) requestOptions() []option.RequestOption {
-	if c.options.topK == nil || c.options.baseURL == "" {
-		return nil
+	var opts []option.RequestOption
+	if c.options.topK != nil && c.options.baseURL != "" {
+		opts = append(opts, option.WithJSONSet("top_k", *c.options.topK))
 	}
-	return []option.RequestOption{option.WithJSONSet("top_k", *c.options.topK)}
+	for k, v := range c.options.extraBodyFields {
+		opts = append(opts, option.WithJSONSet(k, v))
+	}
+	return opts
 }
 
 // SendMessages sends a conversation and returns the complete response.
@@ -498,10 +533,11 @@ func (c *Client) SendMessages(
 			}
 
 			return &llm.Response{
-				Content:      content,
-				ToolCalls:    toolCalls,
-				Usage:        c.usage(*openaiResponse),
-				FinishReason: finishReason,
+				Content:          content,
+				ToolCalls:        toolCalls,
+				Usage:            c.usage(*openaiResponse),
+				FinishReason:     finishReason,
+				ProviderMetadata: c.providerMetadata(*openaiResponse),
 			}, nil
 		},
 	)
@@ -596,10 +632,11 @@ func (c *Client) runStream(
 		}
 
 		resp := &llm.Response{
-			Content:      currentContent,
-			ToolCalls:    toolCalls,
-			Usage:        c.usage(acc.ChatCompletion),
-			FinishReason: finishReason,
+			Content:          currentContent,
+			ToolCalls:        toolCalls,
+			Usage:            c.usage(acc.ChatCompletion),
+			FinishReason:     finishReason,
+			ProviderMetadata: c.providerMetadata(acc.ChatCompletion),
 		}
 		if structured {
 			resp.StructuredOutput = &currentContent
@@ -632,6 +669,11 @@ func (c *Client) toolCalls(
 
 func (c *Client) usage(completion openaisdk.ChatCompletion) llm.TokenUsage {
 	cachedTokens := completion.Usage.PromptTokensDetails.CachedTokens
+	if cachedTokens == 0 {
+		// DeepSeek reports cache hits as a top-level usage field rather than in
+		// prompt_tokens_details; the SDK captures it as an extra field.
+		cachedTokens = extraUsageInt(completion.Usage, "prompt_cache_hit_tokens")
+	}
 	inputTokens := completion.Usage.PromptTokens - cachedTokens
 
 	return llm.TokenUsage{
@@ -639,7 +681,58 @@ func (c *Client) usage(completion openaisdk.ChatCompletion) llm.TokenUsage {
 		OutputTokens:        completion.Usage.CompletionTokens,
 		CacheCreationTokens: 0,
 		CacheReadTokens:     cachedTokens,
+		ReasoningTokens:     completion.Usage.CompletionTokensDetails.ReasoningTokens,
 	}
+}
+
+// extraUsageInt reads an integer usage field the OpenAI SDK does not model
+// natively from the completion usage's JSON extra fields. The SDK reserves
+// respjson.Field.Valid for modeled fields, so extra fields are read via Raw.
+func extraUsageInt(usage openaisdk.CompletionUsage, key string) int64 {
+	field, ok := usage.JSON.ExtraFields[key]
+	if !ok {
+		return 0
+	}
+	raw := field.Raw()
+	if raw == "" || raw == "null" {
+		return 0
+	}
+	var n int64
+	if json.Unmarshal([]byte(raw), &n) != nil {
+		return 0
+	}
+	return n
+}
+
+// providerMetadata extracts the configured top-level response fields (set via
+// WithResponseMetadataField) from the completion's JSON extra fields into a
+// ProviderMetadata map. Returns nil when nothing is configured or present.
+func (c *Client) providerMetadata(
+	completion openaisdk.ChatCompletion,
+) map[string]any {
+	if len(c.options.metadataFields) == 0 {
+		return nil
+	}
+	var meta map[string]any
+	for field, key := range c.options.metadataFields {
+		f, ok := completion.JSON.ExtraFields[field]
+		if !ok {
+			continue
+		}
+		raw := f.Raw()
+		if raw == "" || raw == "null" {
+			continue
+		}
+		var value any
+		if json.Unmarshal([]byte(raw), &value) != nil {
+			continue
+		}
+		if meta == nil {
+			meta = make(map[string]any)
+		}
+		meta[key] = value
+	}
+	return meta
 }
 
 func (c *Client) responseFormatForSchema(
@@ -715,6 +808,7 @@ func (c *Client) SendMessagesWithStructuredOutput(
 				FinishReason:               finishReason,
 				StructuredOutput:           &content,
 				UsedNativeStructuredOutput: true,
+				ProviderMetadata:           c.providerMetadata(*openaiResponse),
 			}, nil
 		},
 	)

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -672,7 +672,10 @@ func (c *Client) usage(completion openaisdk.ChatCompletion) llm.TokenUsage {
 	if cachedTokens == 0 {
 		// DeepSeek reports cache hits as a top-level usage field rather than in
 		// prompt_tokens_details; the SDK captures it as an extra field.
-		cachedTokens = extraUsageInt(completion.Usage, "prompt_cache_hit_tokens")
+		cachedTokens = extraUsageInt(
+			completion.Usage,
+			"prompt_cache_hit_tokens",
+		)
 	}
 	inputTokens := completion.Usage.PromptTokens - cachedTokens
 

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -142,3 +142,125 @@ func TestWireTopKAndStop(t *testing.T) {
 		}
 	}
 }
+
+// TestWireRequestJSONField confirms WithRequestJSONField injects arbitrary
+// top-level fields (objects and arrays) into the request body.
+func TestWireRequestJSONField(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, `{"id":"x","object":"chat.completion",`+
+		`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},`+
+		`"finish_reason":"stop"}],`+
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "x"}),
+		WithRequestJSONField("provider", map[string]any{"allow_fallbacks": false}),
+		WithRequestJSONField("models", []string{"a", "b"}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	provider, ok := body["provider"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected provider object, got %v (%T)",
+			body["provider"], body["provider"])
+	}
+	if provider["allow_fallbacks"] != false {
+		t.Errorf("provider.allow_fallbacks = %v, want false",
+			provider["allow_fallbacks"])
+	}
+	models, ok := body["models"].([]any)
+	if !ok || len(models) != 2 || models[0] != "a" || models[1] != "b" {
+		t.Errorf("models = %v, want [a b]", body["models"])
+	}
+}
+
+// TestResponseMetadataField confirms WithResponseMetadataField surfaces a
+// top-level response field into ProviderMetadata under the namespaced key.
+func TestResponseMetadataField(t *testing.T) {
+	srv := newCompletionServer(t, nil, `{"id":"x","object":"chat.completion",`+
+		`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},`+
+		`"finish_reason":"stop"}],`+
+		`"citations":["https://a.test","https://b.test"],`+
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "x"}),
+		WithResponseMetadataField("citations", "perplexity.citations"),
+	)
+
+	resp, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	cites, ok := resp.ProviderMetadata["perplexity.citations"].([]any)
+	if !ok || len(cites) != 2 || cites[0] != "https://a.test" {
+		t.Fatalf("expected citations in metadata, got %v",
+			resp.ProviderMetadata)
+	}
+}
+
+// TestUsageReasoningAndDeepSeekCache verifies that reasoning_tokens and
+// DeepSeek's top-level prompt_cache_hit_tokens (an SDK extra field) are mapped.
+func TestUsageReasoningAndDeepSeekCache(t *testing.T) {
+	srv := newCompletionServer(t, nil, `{"id":"x","object":"chat.completion",`+
+		`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},`+
+		`"finish_reason":"stop"}],`+
+		`"usage":{"prompt_tokens":100,"completion_tokens":40,"total_tokens":140,`+
+		`"prompt_cache_hit_tokens":80,"prompt_cache_miss_tokens":20,`+
+		`"completion_tokens_details":{"reasoning_tokens":12}}}`)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "deepseek-chat"}),
+	)
+
+	resp, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if resp.Usage.CacheReadTokens != 80 {
+		t.Errorf("CacheReadTokens = %d, want 80", resp.Usage.CacheReadTokens)
+	}
+	if resp.Usage.InputTokens != 20 {
+		t.Errorf("InputTokens = %d, want 20 (prompt - cache hit)",
+			resp.Usage.InputTokens)
+	}
+	if resp.Usage.ReasoningTokens != 12 {
+		t.Errorf("ReasoningTokens = %d, want 12", resp.Usage.ReasoningTokens)
+	}
+}
+
+// newCompletionServer returns a test server that captures the request body into
+// capture (when non-nil) and replies with the given chat-completion JSON.
+func newCompletionServer(
+	t *testing.T,
+	capture *map[string]any,
+	response string,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if capture != nil {
+				raw, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(raw, capture)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, response)
+		}))
+}

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -147,17 +147,24 @@ func TestWireTopKAndStop(t *testing.T) {
 // top-level fields (objects and arrays) into the request body.
 func TestWireRequestJSONField(t *testing.T) {
 	var body map[string]any
-	srv := newCompletionServer(t, &body, `{"id":"x","object":"chat.completion",`+
-		`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},`+
-		`"finish_reason":"stop"}],`+
-		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	srv := newCompletionServer(
+		t,
+		&body,
+		`{"id":"x","object":"chat.completion",`+
+			`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},`+
+			`"finish_reason":"stop"}],`+
+			`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
 	defer srv.Close()
 
 	client := NewLLM(
 		WithAPIKey("test-key"),
 		WithBaseURL(srv.URL),
 		WithModel(model.Model{APIModel: "x"}),
-		WithRequestJSONField("provider", map[string]any{"allow_fallbacks": false}),
+		WithRequestJSONField(
+			"provider",
+			map[string]any{"allow_fallbacks": false},
+		),
 		WithRequestJSONField("models", []string{"a", "b"}),
 	)
 

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -5,6 +5,8 @@ go 1.25.0
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/message v0.1.0
+	github.com/joakimcarlsson/ai/model v0.3.0
 )
 
 require (
@@ -15,8 +17,6 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect

--- a/llm/openrouter/openrouter.go
+++ b/llm/openrouter/openrouter.go
@@ -28,3 +28,29 @@ func NewLLM(opts ...Option) llm.LLM {
 	return llmopenai.NewLLM(
 		append([]Option{llmopenai.WithBaseURL(DefaultBaseURL)}, opts...)...)
 }
+
+// WithProviderRouting sets OpenRouter's provider routing object. order lists
+// provider slugs to try in preference order; allowFallbacks controls whether
+// OpenRouter may fall back to providers outside that list when they are
+// unavailable. See https://openrouter.ai/docs/features/provider-routing.
+func WithProviderRouting(order []string, allowFallbacks bool) Option {
+	provider := map[string]any{"allow_fallbacks": allowFallbacks}
+	if len(order) > 0 {
+		provider["order"] = order
+	}
+	return llmopenai.WithRequestJSONField("provider", provider)
+}
+
+// WithModelFallbacks sets OpenRouter's models fallback array. When the primary
+// model (set via [llmopenai.WithModel]) errors or is unavailable, OpenRouter
+// automatically retries the next model in this list. See
+// https://openrouter.ai/docs/features/model-routing.
+func WithModelFallbacks(models ...string) Option {
+	return llmopenai.WithRequestJSONField("models", models)
+}
+
+// WithTopK limits token sampling to the top K candidates. Re-exported from
+// [llmopenai.WithTopK]; OpenRouter honors top_k for providers that support it.
+func WithTopK(k int64) Option {
+	return llmopenai.WithTopK(k)
+}

--- a/llm/openrouter/openrouter_test.go
+++ b/llm/openrouter/openrouter_test.go
@@ -1,0 +1,71 @@
+package openrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmopenai "github.com/joakimcarlsson/ai/llm/openai"
+	"github.com/joakimcarlsson/ai/llm/openrouter"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+// TestWireRoutingOptions confirms the OpenRouter-specific options reach the
+// request body: the provider routing object, the models fallback array, and
+// top_k.
+func TestWireRoutingOptions(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion",`+
+				`"choices":[{"index":0,"message":{"role":"assistant",`+
+				`"content":"hi"},"finish_reason":"stop"}],`+
+				`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+		}))
+	defer srv.Close()
+
+	client := openrouter.NewLLM(
+		llmopenai.WithAPIKey("test-key"),
+		llmopenai.WithBaseURL(srv.URL),
+		llmopenai.WithModel(model.Model{APIModel: "openai/gpt-4o"}),
+		openrouter.WithProviderRouting([]string{"openai", "azure"}, false),
+		openrouter.WithModelFallbacks("anthropic/claude", "google/gemini"),
+		openrouter.WithTopK(50),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	provider, ok := body["provider"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected provider object, got %v (%T)",
+			body["provider"], body["provider"])
+	}
+	if provider["allow_fallbacks"] != false {
+		t.Errorf("provider.allow_fallbacks = %v, want false",
+			provider["allow_fallbacks"])
+	}
+	order, ok := provider["order"].([]any)
+	if !ok || len(order) != 2 || order[0] != "openai" || order[1] != "azure" {
+		t.Errorf("provider.order = %v, want [openai azure]", provider["order"])
+	}
+
+	models, ok := body["models"].([]any)
+	if !ok || len(models) != 2 || models[0] != "anthropic/claude" {
+		t.Errorf("models = %v, want [anthropic/claude google/gemini]",
+			body["models"])
+	}
+
+	if got, ok := body["top_k"].(float64); !ok || int64(got) != 50 {
+		t.Errorf("top_k = %v (%T), want 50", body["top_k"], body["top_k"])
+	}
+}

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -5,6 +5,8 @@ go 1.25.0
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/message v0.1.0
+	github.com/joakimcarlsson/ai/model v0.1.0
 )
 
 require (
@@ -15,8 +17,6 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect

--- a/llm/perplexity/perplexity.go
+++ b/llm/perplexity/perplexity.go
@@ -1,9 +1,12 @@
 // Package perplexity provides an OpenAI-compatible LLM client targeting
 // Perplexity's Sonar API.
 //
-// This is a thin wrapper over [llm/openai] fixed to Perplexity's
-// chat-completions endpoint. Vendor-unique features (citations metadata,
-// search domain filters) are not surfaced; the OpenAI-compatible subset is.
+// This wraps [llm/openai] fixed to Perplexity's chat-completions endpoint.
+// Beyond the OpenAI-compatible subset, it surfaces Perplexity's vendor features:
+// search-control options (domain/recency filters, related questions, web search
+// options, disabling search) and the citations and search_results returned with
+// every answer, exposed via [llm.Response].ProviderMetadata under
+// [MetadataKeyCitations] and [MetadataKeySearchResults].
 package perplexity
 
 import (
@@ -14,14 +17,57 @@ import (
 // DefaultBaseURL is the canonical Perplexity API endpoint.
 const DefaultBaseURL = "https://api.perplexity.ai"
 
+// ProviderMetadata keys under which Perplexity search data is surfaced on
+// [llm.Response].ProviderMetadata.
+const (
+	MetadataKeyCitations     = "perplexity.citations"
+	MetadataKeySearchResults = "perplexity.search_results"
+)
+
 // Option re-exports [llmopenai.Option] for caller convenience.
 type Option = llmopenai.Option
 
 // NewLLM constructs a Perplexity LLM client.
 //
 // [llmopenai.WithBaseURL] is prepended with [DefaultBaseURL]; pass it again in
-// opts to override.
+// opts to override. The client always surfaces the response citations and
+// search_results into [llm.Response].ProviderMetadata.
 func NewLLM(opts ...Option) llm.LLM {
-	return llmopenai.NewLLM(
-		append([]Option{llmopenai.WithBaseURL(DefaultBaseURL)}, opts...)...)
+	base := []Option{
+		llmopenai.WithBaseURL(DefaultBaseURL),
+		llmopenai.WithResponseMetadataField("citations", MetadataKeyCitations),
+		llmopenai.WithResponseMetadataField(
+			"search_results", MetadataKeySearchResults),
+	}
+	return llmopenai.NewLLM(append(base, opts...)...)
+}
+
+// WithSearchDomainFilter restricts (or, with a leading "-", excludes) the
+// domains Perplexity searches via search_domain_filter.
+func WithSearchDomainFilter(domains ...string) Option {
+	return llmopenai.WithRequestJSONField("search_domain_filter", domains)
+}
+
+// WithSearchRecencyFilter restricts results to a recency window via
+// search_recency_filter (e.g. "day", "week", "month", "year").
+func WithSearchRecencyFilter(recency string) Option {
+	return llmopenai.WithRequestJSONField("search_recency_filter", recency)
+}
+
+// WithReturnRelatedQuestions toggles return_related_questions, asking Perplexity
+// to include follow-up question suggestions.
+func WithReturnRelatedQuestions(enabled bool) Option {
+	return llmopenai.WithRequestJSONField("return_related_questions", enabled)
+}
+
+// WithWebSearchOptions sets the web_search_options object (e.g. search context
+// size, user location) passed through verbatim.
+func WithWebSearchOptions(options map[string]any) Option {
+	return llmopenai.WithRequestJSONField("web_search_options", options)
+}
+
+// WithDisableSearch sets disable_search, turning off web search so the model
+// answers from its own knowledge.
+func WithDisableSearch() Option {
+	return llmopenai.WithRequestJSONField("disable_search", true)
 }

--- a/llm/perplexity/perplexity_test.go
+++ b/llm/perplexity/perplexity_test.go
@@ -1,0 +1,72 @@
+package perplexity_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmopenai "github.com/joakimcarlsson/ai/llm/openai"
+	"github.com/joakimcarlsson/ai/llm/perplexity"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+// TestWireSearchControlsAndMetadata confirms search-control options reach the
+// request body and that citations/search_results surface into ProviderMetadata.
+func TestWireSearchControlsAndMetadata(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion",`+
+				`"choices":[{"index":0,"message":{"role":"assistant",`+
+				`"content":"hi"},"finish_reason":"stop"}],`+
+				`"citations":["https://a.test"],`+
+				`"search_results":[{"title":"A","url":"https://a.test"}],`+
+				`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+		}))
+	defer srv.Close()
+
+	client := perplexity.NewLLM(
+		llmopenai.WithAPIKey("test-key"),
+		llmopenai.WithBaseURL(srv.URL),
+		llmopenai.WithModel(model.Model{APIModel: "sonar"}),
+		perplexity.WithSearchDomainFilter("a.test", "-b.test"),
+		perplexity.WithSearchRecencyFilter("week"),
+		perplexity.WithReturnRelatedQuestions(true),
+	)
+
+	resp, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	domains, ok := body["search_domain_filter"].([]any)
+	if !ok || len(domains) != 2 || domains[0] != "a.test" {
+		t.Errorf("search_domain_filter = %v, want [a.test -b.test]",
+			body["search_domain_filter"])
+	}
+	if body["search_recency_filter"] != "week" {
+		t.Errorf("search_recency_filter = %v, want week",
+			body["search_recency_filter"])
+	}
+	if body["return_related_questions"] != true {
+		t.Errorf("return_related_questions = %v, want true",
+			body["return_related_questions"])
+	}
+
+	cites, ok := resp.ProviderMetadata[perplexity.MetadataKeyCitations].([]any)
+	if !ok || len(cites) != 1 || cites[0] != "https://a.test" {
+		t.Errorf("citations metadata = %v", resp.ProviderMetadata)
+	}
+	results, ok := resp.ProviderMetadata[perplexity.MetadataKeySearchResults].([]any)
+	if !ok || len(results) != 1 {
+		t.Errorf("search_results metadata = %v", resp.ProviderMetadata)
+	}
+}


### PR DESCRIPTION
closes #172 

This pull request introduces several enhancements and new features to the LLM provider wrappers, focusing on improved support for vendor-specific fields, token usage tracking, and configuration flexibility. The most significant changes include adding support for arbitrary request and response fields in OpenAI-compatible providers, surfacing reasoning token usage across providers, and extending Gemini's configuration options. Thorough tests are added to verify these behaviors.