### PR TITLE
fix(llm/gemini): tool-result role "user" + Gemini-3 thought-signature replay

### DIFF
--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -268,6 +268,9 @@ func (c *Client) convertMessages(
 						Name: toolCall.Name,
 						Args: args,
 					},
+					// Replay the captured thought signature so Gemini 3 accepts
+					// the follow-up turn (see ToolCall.ThoughtSignature).
+					ThoughtSignature: toolCall.ThoughtSignature,
 				})
 			}
 			if len(parts) > 0 {
@@ -286,8 +289,14 @@ func (c *Client) convertMessages(
 						},
 					},
 				}}
+				// Gemini rejects Role != ("user"|"model"): sending "function"
+				// yields `400 INVALID_ARGUMENT: Role must be user or model, but
+				// got function`, which kills the chat loop on the first tool turn
+				// (observed in overtura's datasource setup-agent, 2026-05-27).
+				// Function responses are sent with role="user" — Google's model
+				// treats tool output as coming from the user side.
 				geminiMessages = append(geminiMessages, &genai.Content{
-					Role: "function", Parts: parts,
+					Role: "user", Parts: parts,
 				})
 			}
 		}
@@ -453,11 +462,12 @@ func (c *Client) SendMessages(
 						id := "call_" + uuid.New().String()
 						args, _ := json.Marshal(part.FunctionCall.Args)
 						toolCalls = append(toolCalls, message.ToolCall{
-							ID:       id,
-							Name:     part.FunctionCall.Name,
-							Input:    string(args),
-							Type:     "function",
-							Finished: true,
+							ID:               id,
+							Name:             part.FunctionCall.Name,
+							Input:            string(args),
+							Type:             "function",
+							Finished:         true,
+							ThoughtSignature: part.ThoughtSignature,
 						})
 						continue
 					}
@@ -544,10 +554,11 @@ func (c *Client) SendMessagesWithStructuredOutput(
 					if part.FunctionCall != nil {
 						input, _ := json.Marshal(part.FunctionCall.Args)
 						toolCalls = append(toolCalls, message.ToolCall{
-							ID:    part.FunctionCall.Name,
-							Name:  part.FunctionCall.Name,
-							Input: string(input),
-							Type:  "function",
+							ID:               part.FunctionCall.Name,
+							Name:             part.FunctionCall.Name,
+							Input:            string(input),
+							Type:             "function",
+							ThoughtSignature: part.ThoughtSignature,
 						})
 						continue
 					}
@@ -667,11 +678,12 @@ func (c *Client) streamInternal(
 							id := "call_" + uuid.New().String()
 							args, _ := json.Marshal(part.FunctionCall.Args)
 							newCall := message.ToolCall{
-								ID:       id,
-								Name:     part.FunctionCall.Name,
-								Input:    string(args),
-								Type:     "function",
-								Finished: true,
+								ID:               id,
+								Name:             part.FunctionCall.Name,
+								Input:            string(args),
+								Type:             "function",
+								Finished:         true,
+								ThoughtSignature: part.ThoughtSignature,
 							}
 
 							isNew := true

--- a/llm/gemini/gemini_tool_fixes_test.go
+++ b/llm/gemini/gemini_tool_fixes_test.go
@@ -1,0 +1,75 @@
+package gemini
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+)
+
+// TestGemini_ToolResultRoleIsUser verifies function/tool results are sent with
+// role "user" (Gemini rejects role "function" with a 400 that kills the loop).
+func TestGemini_ToolResultRoleIsUser(t *testing.T) {
+	c := &Client{}
+	toolMsg := message.NewMessage(message.Tool, nil)
+	toolMsg.AddToolResult(message.ToolResult{ToolCallID: "1", Name: "search", Content: "result"})
+
+	contents, _ := c.convertMessages([]message.Message{toolMsg})
+	if len(contents) == 0 {
+		t.Fatalf("expected a tool-result content")
+	}
+	last := contents[len(contents)-1]
+	if last.Role != "user" {
+		t.Errorf("tool-result role = %q, want user", last.Role)
+	}
+	if len(last.Parts) == 0 || last.Parts[0].FunctionResponse == nil {
+		t.Errorf("expected a FunctionResponse part on the tool-result content")
+	}
+}
+
+// TestGemini_ThoughtSignatureReplay verifies a stored ToolCall.ThoughtSignature
+// is replayed onto the outgoing function-call part so Gemini 3 accepts the turn.
+func TestGemini_ThoughtSignatureReplay(t *testing.T) {
+	sig := []byte("opaque-thought-sig")
+	c := &Client{}
+	asst := message.NewAssistantMessage()
+	asst.AppendToolCalls([]message.ToolCall{{
+		Name:             "search",
+		Input:            "{}",
+		Type:             "function",
+		ThoughtSignature: sig,
+	}})
+
+	contents, _ := c.convertMessages([]message.Message{asst})
+	var found bool
+	for _, ct := range contents {
+		for _, p := range ct.Parts {
+			if p.FunctionCall != nil {
+				found = true
+				if !bytes.Equal(p.ThoughtSignature, sig) {
+					t.Errorf("replayed ThoughtSignature = %q, want %q", p.ThoughtSignature, sig)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected a function-call part in the converted messages")
+	}
+}
+
+// TestGemini_NoThoughtSignatureIsClean verifies a tool call without a signature
+// produces a nil/empty signature on the part (no spurious bytes).
+func TestGemini_NoThoughtSignatureIsClean(t *testing.T) {
+	c := &Client{}
+	asst := message.NewAssistantMessage()
+	asst.AppendToolCalls([]message.ToolCall{{Name: "search", Input: "{}", Type: "function"}})
+
+	contents, _ := c.convertMessages([]message.Message{asst})
+	for _, ct := range contents {
+		for _, p := range ct.Parts {
+			if p.FunctionCall != nil && len(p.ThoughtSignature) != 0 {
+				t.Errorf("expected empty ThoughtSignature, got %q", p.ThoughtSignature)
+			}
+		}
+	}
+}

--- a/message/base.go
+++ b/message/base.go
@@ -74,6 +74,12 @@ type ToolCall struct {
 	Type string `json:"type"`
 	// Finished indicates whether the tool call has completed execution.
 	Finished bool `json:"finished"`
+	// ThoughtSignature carries the provider's opaque signature for the reasoning
+	// that produced this tool call (Gemini 3 thinking models). It must be captured
+	// from the response and replayed on the next request's matching function-call
+	// part, or Gemini rejects the follow-up turn. Empty for providers/models that
+	// don't emit one.
+	ThoughtSignature []byte `json:"thought_signature,omitempty"`
 }
 
 func (ToolCall) isPart() {}


### PR DESCRIPTION
Two correctness fixes for Gemini tool calling, surfaced while running Gemini 3 with tools in production.

## 1. Tool results sent with role `function` → 400
Function/tool results were emitted with `Role: "function"`. The Gemini API rejects that and expects `role: "user"` for `functionResponse` parts, so any tool-using turn 400s. Fixed in `convertMessages`.

## 2. Gemini-3 `thought_signature` must be replayed
Gemini 3 returns an opaque `thought_signature` on function-call parts. It must be replayed on the follow-up turn or the model rejects the continuation. This adds `message.ToolCall.ThoughtSignature ([]byte)` to carry it across turns; the client captures it from the response and replays it on the outgoing function-call part (the field is on `genai.Part`, not inside `FunctionCall`, at genai v1.58).

## Tests
`llm/gemini/gemini_tool_fixes_test.go` covers the tool-result role, thought-signature replay, and the no-signature clean path. `go test ./...` green for `llm/gemini` and `message`.

Surfaced and validated in the Overtura fork; offering upstream since both are plain API-compatibility fixes.