### PR TITLE
chore: cascade message@v0.2.0 into gemini + vertexai consumers

### DIFF
--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/message v0.1.0
+	github.com/joakimcarlsson/ai/message v0.2.0
 	github.com/joakimcarlsson/ai/model v0.2.0
 	github.com/joakimcarlsson/ai/schema v0.1.0
 	github.com/joakimcarlsson/ai/tool v0.1.0

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/gemini v0.1.0
+	github.com/joakimcarlsson/ai/llm/gemini v0.2.3
 	github.com/joakimcarlsson/ai/model v0.2.0
 	google.golang.org/genai v1.58.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.1.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect


### PR DESCRIPTION
Follow-up to #181 to make the Gemini tool fixes resolve correctly for `go get` consumers.

#181 added `message.ToolCall.ThoughtSignature`, a new exported field, bumping `message` from `v0.1.0` to `v0.2.0`. The consuming modules must require the new `message` version, or MVS resolves `message@v0.1.0` (no field) and the build breaks.

## Changes
- **`llm/gemini`**: require `message@v0.2.0` (it now reads/writes `ThoughtSignature`).
- **`llm/vertexai`**: require `llm/gemini@v0.2.3` + `message@v0.2.0`. This also corrects a stale `llm/gemini v0.1.0` pin so Vertex users pick up current gemini logic, including this fix (vertexai embeds gemini's `convertMessages`).

## Tags after merge
- `message/v0.2.0`
- `llm/gemini/v0.2.3`
- `llm/vertexai/v0.1.3`

Both modules `go build ./...` clean with the new requires.