### PR TITLE
fix: append to os.Environ() for MCP stdio env vars

### DIFF
--- a/examples/llm/tool-calling/main.go
+++ b/examples/llm/tool-calling/main.go
@@ -117,12 +117,20 @@ func newLLM() (llm.LLM, string) {
 			llmanthropic.WithAPIKey(requiredEnv("ANTHROPIC_API_KEY")),
 			llmanthropic.WithModel(model.AnthropicModels[model.Claude45Haiku]),
 			llmanthropic.WithMaxTokens(512),
+			// Force a tool call on the first turn instead of letting the model
+			// answer from prior knowledge.
+			llmanthropic.WithToolChoice(
+				llm.ToolChoice{Mode: llm.ToolChoiceRequired},
+			),
 		), provider
 	case "gemini":
 		return llmgemini.NewLLM(
 			llmgemini.WithAPIKey(requiredEnv("GEMINI_API_KEY")),
 			llmgemini.WithModel(model.GeminiModels[model.Gemini25FlashLite]),
 			llmgemini.WithMaxTokens(512),
+			llmgemini.WithToolChoice(
+				llm.ToolChoice{Mode: llm.ToolChoiceRequired},
+			),
 		), provider
 	case "openai":
 		return llmopenai.NewLLM(
@@ -130,6 +138,9 @@ func newLLM() (llm.LLM, string) {
 			llmopenai.WithModel(model.OpenAIModels[model.GPT54Nano]),
 			llmopenai.WithMaxTokens(512),
 			llmopenai.WithParallelToolCalls(false),
+			llmopenai.WithToolChoice(
+				llm.ToolChoice{Mode: llm.ToolChoiceRequired},
+			),
 		), provider
 	default:
 		log.Fatalf(

--- a/llm/anthropic/anthropic.go
+++ b/llm/anthropic/anthropic.go
@@ -50,6 +50,7 @@ type Options struct {
 	useBedrock      bool
 	disableCache    bool
 	reasoningEffort *ReasoningEffort
+	toolChoice      *llm.ToolChoice
 	builtinTools    []anthropicsdk.ToolUnionParam
 }
 
@@ -111,6 +112,14 @@ func WithDisableCache() Option { return func(o *Options) { o.disableCache = true
 // WithReasoningEffort sets the reasoning/thinking effort level.
 func WithReasoningEffort(effort ReasoningEffort) Option {
 	return func(o *Options) { o.reasoningEffort = &effort }
+}
+
+// WithToolChoice controls whether and which tool the model may call. It maps to
+// Anthropic's tool_choice field: {"type":"auto"} / {"type":"none"} /
+// {"type":"any"} / {"type":"tool","name":...}. The field is emitted only when
+// tools are sent.
+func WithToolChoice(choice llm.ToolChoice) Option {
+	return func(o *Options) { o.toolChoice = &choice }
 }
 
 // WebSearchConfig configures the Anthropic server-side web_search tool.
@@ -368,6 +377,27 @@ func (c *Client) convertTools(
 	return append(out, c.options.builtinTools...)
 }
 
+// toolChoiceParam maps a vendor-neutral [llm.ToolChoice] to Anthropic's
+// tool_choice union: {"type":"auto"} / {"type":"none"} / {"type":"any"} for the
+// required case, or {"type":"tool","name":...} for [llm.ToolChoiceSpecific].
+func toolChoiceParam(choice llm.ToolChoice) anthropicsdk.ToolChoiceUnionParam {
+	switch choice.Mode {
+	case llm.ToolChoiceNone:
+		none := anthropicsdk.NewToolChoiceNoneParam()
+		return anthropicsdk.ToolChoiceUnionParam{OfNone: &none}
+	case llm.ToolChoiceRequired:
+		return anthropicsdk.ToolChoiceUnionParam{
+			OfAny: &anthropicsdk.ToolChoiceAnyParam{},
+		}
+	case llm.ToolChoiceSpecific:
+		return anthropicsdk.ToolChoiceParamOfTool(choice.Name)
+	default:
+		return anthropicsdk.ToolChoiceUnionParam{
+			OfAuto: &anthropicsdk.ToolChoiceAutoParam{},
+		}
+	}
+}
+
 func (c *Client) finishReason(reason string) message.FinishReason {
 	switch reason {
 	case "end_turn":
@@ -464,6 +494,10 @@ func (c *Client) preparedMessages(
 		params.StopSequences = c.options.stopSequences
 	}
 
+	if c.options.toolChoice != nil && len(tools) > 0 {
+		params.ToolChoice = toolChoiceParam(*c.options.toolChoice)
+	}
+
 	if len(systemMessages) > 0 {
 		systemBlocks := make([]anthropicsdk.TextBlockParam, len(systemMessages))
 		for i, sysMsg := range systemMessages {
@@ -481,12 +515,33 @@ func (c *Client) preparedMessages(
 	return params
 }
 
+// validateToolChoice rejects a malformed tool choice before a request is sent.
+func (c *Client) validateToolChoice() error {
+	if c.options.toolChoice == nil {
+		return nil
+	}
+	return c.options.toolChoice.Validate()
+}
+
+// errorEvent returns a closed channel carrying a single error event, used to
+// surface pre-flight failures (such as an invalid tool choice) on the streaming
+// API where the method signature has no error return.
+func errorEvent(err error) <-chan llm.Event {
+	eventChan := make(chan llm.Event, 1)
+	eventChan <- llm.Event{Type: types.EventError, Error: err}
+	close(eventChan)
+	return eventChan
+}
+
 // SendMessages sends a conversation and returns the complete response.
 func (c *Client) SendMessages(
 	ctx context.Context,
 	messages []message.Message,
 	tools []tool.BaseTool,
 ) (*llm.Response, error) {
+	if err := c.validateToolChoice(); err != nil {
+		return nil, err
+	}
 	anthropicMessages, systemMessages := c.convertMessages(messages)
 	preparedMessages := c.preparedMessages(
 		anthropicMessages, c.convertTools(tools), systemMessages,
@@ -527,6 +582,9 @@ func (c *Client) StreamResponse(
 	messages []message.Message,
 	tools []tool.BaseTool,
 ) <-chan llm.Event {
+	if err := c.validateToolChoice(); err != nil {
+		return errorEvent(err)
+	}
 	anthropicMessages, systemMessages := c.convertMessages(messages)
 	preparedMessages := c.preparedMessages(
 		anthropicMessages, c.convertTools(tools), systemMessages,
@@ -724,6 +782,9 @@ func (c *Client) SendMessagesWithStructuredOutput(
 	tools []tool.BaseTool,
 	outputSchema *schema.StructuredOutputInfo,
 ) (*llm.Response, error) {
+	if err := c.validateToolChoice(); err != nil {
+		return nil, err
+	}
 	anthropicMessages, systemMessages := c.convertMessages(messages)
 	preparedMessages := c.preparedMessages(
 		anthropicMessages, c.convertTools(tools), systemMessages,
@@ -768,6 +829,9 @@ func (c *Client) StreamResponseWithStructuredOutput(
 	tools []tool.BaseTool,
 	outputSchema *schema.StructuredOutputInfo,
 ) <-chan llm.Event {
+	if err := c.validateToolChoice(); err != nil {
+		return errorEvent(err)
+	}
 	anthropicMessages, systemMessages := c.convertMessages(messages)
 	preparedMessages := c.preparedMessages(
 		anthropicMessages, c.convertTools(tools), systemMessages,

--- a/llm/anthropic/anthropic_test.go
+++ b/llm/anthropic/anthropic_test.go
@@ -1,0 +1,119 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+// stubTool is a no-op BaseTool used to populate the request's tools slice so
+// tool-choice assertions have something to attach to.
+type stubTool struct{ name string }
+
+func (s stubTool) Info() tool.Info {
+	return tool.Info{Name: s.name, Description: "d", Parameters: map[string]any{}}
+}
+
+func (s stubTool) Run(context.Context, tool.Call) (tool.Response, error) {
+	return tool.Response{}, nil
+}
+
+func optsFrom(opts ...Option) Options {
+	o := Options{}
+	for _, f := range opts {
+		f(&o)
+	}
+	return o
+}
+
+// toolChoiceBody builds a request for the given options and one tool, then
+// returns the marshaled request body as a generic map for wire assertions.
+func toolChoiceBody(t *testing.T, tools []tool.BaseTool, opts ...Option) map[string]any {
+	t.Helper()
+	c := &Client{options: optsFrom(opts...)}
+	params := c.preparedMessages(nil, c.convertTools(tools), nil)
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	return body
+}
+
+// TestToolChoiceRequired confirms a Required choice maps to {"type":"any"}.
+func TestToolChoiceRequired(t *testing.T) {
+	body := toolChoiceBody(t,
+		[]tool.BaseTool{stubTool{name: "get_weather"}},
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}))
+
+	tc, ok := body["tool_choice"].(map[string]any)
+	if !ok || tc["type"] != "any" {
+		t.Fatalf("tool_choice = %v, want {type:any}", body["tool_choice"])
+	}
+}
+
+// TestToolChoiceNone confirms a None choice maps to {"type":"none"}.
+func TestToolChoiceNone(t *testing.T) {
+	body := toolChoiceBody(t,
+		[]tool.BaseTool{stubTool{name: "get_weather"}},
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceNone}))
+
+	tc, ok := body["tool_choice"].(map[string]any)
+	if !ok || tc["type"] != "none" {
+		t.Fatalf("tool_choice = %v, want {type:none}", body["tool_choice"])
+	}
+}
+
+// TestToolChoiceSpecific confirms a Specific choice names the tool via
+// {"type":"tool","name":...}.
+func TestToolChoiceSpecific(t *testing.T) {
+	body := toolChoiceBody(t,
+		[]tool.BaseTool{stubTool{name: "get_weather"}},
+		WithToolChoice(llm.ToolChoice{
+			Mode: llm.ToolChoiceSpecific,
+			Name: "get_weather",
+		}))
+
+	tc, ok := body["tool_choice"].(map[string]any)
+	if !ok || tc["type"] != "tool" || tc["name"] != "get_weather" {
+		t.Fatalf("tool_choice = %v, want {type:tool,name:get_weather}",
+			body["tool_choice"])
+	}
+}
+
+// TestToolChoiceOmittedWithoutTools confirms no tool_choice is emitted when the
+// tools slice is empty.
+func TestToolChoiceOmittedWithoutTools(t *testing.T) {
+	body := toolChoiceBody(t, nil,
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}))
+
+	if _, present := body["tool_choice"]; present {
+		t.Errorf("tool_choice should be omitted with no tools, got %v",
+			body["tool_choice"])
+	}
+}
+
+// TestToolChoiceSpecificEmptyNameRejected confirms a Specific choice with no
+// name is rejected before any request is sent.
+func TestToolChoiceSpecificEmptyNameRejected(t *testing.T) {
+	c := &Client{options: optsFrom(
+		WithModel(model.Model{APIModel: "claude"}),
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceSpecific}),
+	)}
+
+	_, err := c.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")},
+		[]tool.BaseTool{stubTool{name: "get_weather"}})
+	if !errors.Is(err, llm.ErrToolChoiceNameRequired) {
+		t.Fatalf("expected ErrToolChoiceNameRequired, got %v", err)
+	}
+}

--- a/llm/anthropic/live_toolchoice_test.go
+++ b/llm/anthropic/live_toolchoice_test.go
@@ -1,0 +1,83 @@
+//go:build live
+
+package anthropic
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type liveWeatherTool struct{}
+
+func (liveWeatherTool) Info() tool.Info {
+	return tool.Info{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city.",
+		Parameters: map[string]any{
+			"city": map[string]any{"type": "string", "description": "City name"},
+		},
+		Required: []string{"city"},
+	}
+}
+
+func (liveWeatherTool) Run(context.Context, tool.Call) (tool.Response, error) {
+	return tool.Response{Content: "sunny, 20C"}, nil
+}
+
+func liveAnthropic(t *testing.T, tc llm.ToolChoice) llm.LLM {
+	key := os.Getenv("ANTHROPIC_API_KEY")
+	if key == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+	return NewLLM(
+		WithAPIKey(key),
+		WithModel(model.AnthropicModels[model.Claude45Haiku]),
+		WithMaxTokens(256),
+		WithToolChoice(tc),
+	)
+}
+
+func send(t *testing.T, c llm.LLM, prompt string) *llm.Response {
+	t.Helper()
+	resp, err := c.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage(prompt)},
+		[]tool.BaseTool{liveWeatherTool{}})
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+	return resp
+}
+
+func TestLiveAnthropicRequired(t *testing.T) {
+	resp := send(t, liveAnthropic(t, llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+		"Say hello in one word.")
+	if len(resp.ToolCalls) == 0 {
+		t.Fatalf("Required: expected a tool call, got content=%q", resp.Content)
+	}
+	t.Logf("Required: tool calls=%d first=%s", len(resp.ToolCalls), resp.ToolCalls[0].Name)
+}
+
+func TestLiveAnthropicNone(t *testing.T) {
+	resp := send(t, liveAnthropic(t, llm.ToolChoice{Mode: llm.ToolChoiceNone}),
+		"What is the weather in Paris? Use the tool.")
+	if len(resp.ToolCalls) != 0 {
+		t.Fatalf("None: expected no tool call, got %d", len(resp.ToolCalls))
+	}
+	t.Logf("None: content=%q", resp.Content)
+}
+
+func TestLiveAnthropicSpecific(t *testing.T) {
+	resp := send(t, liveAnthropic(t,
+		llm.ToolChoice{Mode: llm.ToolChoiceSpecific, Name: "get_weather"}),
+		"Say hello in one word.")
+	if len(resp.ToolCalls) == 0 || resp.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("Specific: expected get_weather call, got %+v", resp.ToolCalls)
+	}
+	t.Logf("Specific: called %s", resp.ToolCalls[0].Name)
+}

--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -48,6 +48,7 @@ type Options struct {
 	seed             *int64
 	thinkingLevel    *ThinkingLevel
 	thinkingBudget   *int32
+	toolChoice       *llm.ToolChoice
 	builtinTools     []*genai.Tool
 }
 
@@ -132,6 +133,14 @@ func WithThinkingBudget(tokens int) Option {
 		b := int32(tokens)
 		o.thinkingBudget = &b
 	}
+}
+
+// WithToolChoice controls whether and which tool the model may call. It maps to
+// Gemini's toolConfig.functionCallingConfig.mode (AUTO / NONE / ANY), with
+// allowedFunctionNames set to the named tool for [llm.ToolChoiceSpecific]. The
+// config is emitted only when tools are sent.
+func WithToolChoice(choice llm.ToolChoice) Option {
+	return func(o *Options) { o.toolChoice = &choice }
 }
 
 // WithGoogleSearch enables Gemini's built-in Google Search grounding tool.
@@ -407,9 +416,39 @@ func (c *Client) buildConfig(
 
 	if len(tools) > 0 || len(c.options.builtinTools) > 0 {
 		config.Tools = c.convertTools(tools)
+		if c.options.toolChoice != nil {
+			config.ToolConfig = toolConfigParam(*c.options.toolChoice)
+		}
 	}
 
 	return config
+}
+
+// toolConfigParam maps a vendor-neutral [llm.ToolChoice] to Gemini's
+// toolConfig.functionCallingConfig: mode AUTO / NONE / ANY, with
+// allowedFunctionNames naming the tool for [llm.ToolChoiceSpecific].
+func toolConfigParam(choice llm.ToolChoice) *genai.ToolConfig {
+	fc := &genai.FunctionCallingConfig{}
+	switch choice.Mode {
+	case llm.ToolChoiceNone:
+		fc.Mode = genai.FunctionCallingConfigModeNone
+	case llm.ToolChoiceRequired:
+		fc.Mode = genai.FunctionCallingConfigModeAny
+	case llm.ToolChoiceSpecific:
+		fc.Mode = genai.FunctionCallingConfigModeAny
+		fc.AllowedFunctionNames = []string{choice.Name}
+	default:
+		fc.Mode = genai.FunctionCallingConfigModeAuto
+	}
+	return &genai.ToolConfig{FunctionCallingConfig: fc}
+}
+
+// validateToolChoice rejects a malformed tool choice before a request is sent.
+func (c *Client) validateToolChoice() error {
+	if c.options.toolChoice == nil {
+		return nil
+	}
+	return c.options.toolChoice.Validate()
 }
 
 // SendMessages sends a conversation and returns the complete response.
@@ -418,6 +457,9 @@ func (c *Client) SendMessages(
 	messages []message.Message,
 	tools []tool.BaseTool,
 ) (*llm.Response, error) {
+	if err := c.validateToolChoice(); err != nil {
+		return nil, err
+	}
 	geminiMessages, systemMessages := c.convertMessages(messages)
 
 	ctx, cancel := llm.ApplyTimeout(ctx, c.options.timeout)
@@ -509,6 +551,9 @@ func (c *Client) SendMessagesWithStructuredOutput(
 	tools []tool.BaseTool,
 	outputSchema *schema.StructuredOutputInfo,
 ) (*llm.Response, error) {
+	if err := c.validateToolChoice(); err != nil {
+		return nil, err
+	}
 	geminiMessages, systemMessages := c.convertMessages(messages)
 
 	ctx, cancel := llm.ApplyTimeout(ctx, c.options.timeout)
@@ -605,6 +650,12 @@ func (c *Client) streamInternal(
 	tools []tool.BaseTool,
 	outputSchema *schema.StructuredOutputInfo,
 ) <-chan llm.Event {
+	if err := c.validateToolChoice(); err != nil {
+		eventChan := make(chan llm.Event, 1)
+		eventChan <- llm.Event{Type: types.EventError, Error: err}
+		close(eventChan)
+		return eventChan
+	}
 	geminiMessages, systemMessages := c.convertMessages(messages)
 
 	ctx, cancel := llm.ApplyTimeout(ctx, c.options.timeout)

--- a/llm/gemini/gemini_tool_choice_test.go
+++ b/llm/gemini/gemini_tool_choice_test.go
@@ -1,0 +1,116 @@
+package gemini
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/tool"
+	"google.golang.org/genai"
+)
+
+// stubTool is a no-op BaseTool used to populate the request's tools slice so
+// tool-choice assertions have something to attach to.
+type stubTool struct{ name string }
+
+func (s stubTool) Info() tool.Info {
+	return tool.Info{Name: s.name, Description: "d", Parameters: map[string]any{}}
+}
+
+func (s stubTool) Run(context.Context, tool.Call) (tool.Response, error) {
+	return tool.Response{}, nil
+}
+
+func clientWith(opts ...Option) *Client {
+	o := Options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Client{options: o}
+}
+
+func functionCallingConfig(t *testing.T, cfg *genai.GenerateContentConfig) *genai.FunctionCallingConfig {
+	t.Helper()
+	if cfg.ToolConfig == nil || cfg.ToolConfig.FunctionCallingConfig == nil {
+		t.Fatal("expected toolConfig.functionCallingConfig to be set")
+	}
+	return cfg.ToolConfig.FunctionCallingConfig
+}
+
+// TestToolChoiceRequired confirms a Required choice maps mode to ANY.
+func TestToolChoiceRequired(t *testing.T) {
+	cfg := clientWith(
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+	).buildConfig(nil, []tool.BaseTool{stubTool{name: "get_weather"}})
+
+	fc := functionCallingConfig(t, cfg)
+	if fc.Mode != genai.FunctionCallingConfigModeAny {
+		t.Errorf("mode = %q, want ANY", fc.Mode)
+	}
+	if len(fc.AllowedFunctionNames) != 0 {
+		t.Errorf("AllowedFunctionNames = %v, want empty", fc.AllowedFunctionNames)
+	}
+}
+
+// TestToolChoiceNone confirms a None choice maps mode to NONE.
+func TestToolChoiceNone(t *testing.T) {
+	cfg := clientWith(
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceNone}),
+	).buildConfig(nil, []tool.BaseTool{stubTool{name: "get_weather"}})
+
+	if fc := functionCallingConfig(t, cfg); fc.Mode != genai.FunctionCallingConfigModeNone {
+		t.Errorf("mode = %q, want NONE", fc.Mode)
+	}
+}
+
+// TestToolChoiceSpecific confirms a Specific choice maps mode to ANY and lists
+// the named tool in allowedFunctionNames.
+func TestToolChoiceSpecific(t *testing.T) {
+	cfg := clientWith(
+		WithToolChoice(llm.ToolChoice{
+			Mode: llm.ToolChoiceSpecific,
+			Name: "get_weather",
+		}),
+	).buildConfig(nil, []tool.BaseTool{stubTool{name: "get_weather"}})
+
+	fc := functionCallingConfig(t, cfg)
+	if fc.Mode != genai.FunctionCallingConfigModeAny {
+		t.Errorf("mode = %q, want ANY", fc.Mode)
+	}
+	if len(fc.AllowedFunctionNames) != 1 || fc.AllowedFunctionNames[0] != "get_weather" {
+		t.Errorf("AllowedFunctionNames = %v, want [get_weather]",
+			fc.AllowedFunctionNames)
+	}
+}
+
+// TestToolChoiceOmittedWithoutTools confirms no toolConfig is emitted when the
+// tools slice is empty.
+func TestToolChoiceOmittedWithoutTools(t *testing.T) {
+	cfg := clientWith(
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+	).buildConfig(nil, nil)
+
+	if cfg.ToolConfig != nil {
+		t.Errorf("toolConfig should be omitted with no tools, got %v",
+			cfg.ToolConfig)
+	}
+}
+
+// TestToolChoiceSpecificEmptyNameRejected confirms a Specific choice with no
+// name is rejected before any request is sent.
+func TestToolChoiceSpecificEmptyNameRejected(t *testing.T) {
+	c := clientWith(
+		WithModel(model.Model{APIModel: "gemini-2.5-flash"}),
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceSpecific}),
+	)
+
+	_, err := c.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")},
+		[]tool.BaseTool{stubTool{name: "get_weather"}})
+	if !errors.Is(err, llm.ErrToolChoiceNameRequired) {
+		t.Fatalf("expected ErrToolChoiceNameRequired, got %v", err)
+	}
+}

--- a/llm/gemini/live_toolchoice_test.go
+++ b/llm/gemini/live_toolchoice_test.go
@@ -1,0 +1,83 @@
+//go:build live
+
+package gemini
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type liveWeatherTool struct{}
+
+func (liveWeatherTool) Info() tool.Info {
+	return tool.Info{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city.",
+		Parameters: map[string]any{
+			"city": map[string]any{"type": "string", "description": "City name"},
+		},
+		Required: []string{"city"},
+	}
+}
+
+func (liveWeatherTool) Run(context.Context, tool.Call) (tool.Response, error) {
+	return tool.Response{Content: "sunny, 20C"}, nil
+}
+
+func liveGemini(t *testing.T, tc llm.ToolChoice) llm.LLM {
+	key := os.Getenv("GEMINI_API_KEY")
+	if key == "" {
+		t.Skip("GEMINI_API_KEY not set")
+	}
+	return NewLLM(
+		WithAPIKey(key),
+		WithModel(model.GeminiModels[model.Gemini25FlashLite]),
+		WithMaxTokens(256),
+		WithToolChoice(tc),
+	)
+}
+
+func send(t *testing.T, c llm.LLM, prompt string) *llm.Response {
+	t.Helper()
+	resp, err := c.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage(prompt)},
+		[]tool.BaseTool{liveWeatherTool{}})
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+	return resp
+}
+
+func TestLiveGeminiRequired(t *testing.T) {
+	resp := send(t, liveGemini(t, llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+		"Say hello in one word.")
+	if len(resp.ToolCalls) == 0 {
+		t.Fatalf("Required: expected a tool call, got content=%q", resp.Content)
+	}
+	t.Logf("Required: tool calls=%d first=%s", len(resp.ToolCalls), resp.ToolCalls[0].Name)
+}
+
+func TestLiveGeminiNone(t *testing.T) {
+	resp := send(t, liveGemini(t, llm.ToolChoice{Mode: llm.ToolChoiceNone}),
+		"What is the weather in Paris? Use the tool.")
+	if len(resp.ToolCalls) != 0 {
+		t.Fatalf("None: expected no tool call, got %d", len(resp.ToolCalls))
+	}
+	t.Logf("None: content=%q", resp.Content)
+}
+
+func TestLiveGeminiSpecific(t *testing.T) {
+	resp := send(t, liveGemini(t,
+		llm.ToolChoice{Mode: llm.ToolChoiceSpecific, Name: "get_weather"}),
+		"Say hello in one word.")
+	if len(resp.ToolCalls) == 0 || resp.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("Specific: expected get_weather call, got %+v", resp.ToolCalls)
+	}
+	t.Logf("Specific: called %s", resp.ToolCalls[0].Name)
+}

--- a/llm/openai/live_toolchoice_test.go
+++ b/llm/openai/live_toolchoice_test.go
@@ -1,0 +1,83 @@
+//go:build live
+
+package openai
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type liveWeatherTool struct{}
+
+func (liveWeatherTool) Info() tool.Info {
+	return tool.Info{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city.",
+		Parameters: map[string]any{
+			"city": map[string]any{"type": "string", "description": "City name"},
+		},
+		Required: []string{"city"},
+	}
+}
+
+func (liveWeatherTool) Run(context.Context, tool.Call) (tool.Response, error) {
+	return tool.Response{Content: "sunny, 20C"}, nil
+}
+
+func liveOpenAI(t *testing.T, tc llm.ToolChoice) llm.LLM {
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	return NewLLM(
+		WithAPIKey(key),
+		WithModel(model.OpenAIModels[model.GPT54Nano]),
+		WithMaxTokens(256),
+		WithToolChoice(tc),
+	)
+}
+
+func send(t *testing.T, c llm.LLM, prompt string) *llm.Response {
+	t.Helper()
+	resp, err := c.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage(prompt)},
+		[]tool.BaseTool{liveWeatherTool{}})
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+	return resp
+}
+
+func TestLiveOpenAIRequired(t *testing.T) {
+	resp := send(t, liveOpenAI(t, llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+		"Say hello in one word.")
+	if len(resp.ToolCalls) == 0 {
+		t.Fatalf("Required: expected a tool call, got content=%q", resp.Content)
+	}
+	t.Logf("Required: tool calls=%d first=%s", len(resp.ToolCalls), resp.ToolCalls[0].Name)
+}
+
+func TestLiveOpenAINone(t *testing.T) {
+	resp := send(t, liveOpenAI(t, llm.ToolChoice{Mode: llm.ToolChoiceNone}),
+		"What is the weather in Paris? Use the tool.")
+	if len(resp.ToolCalls) != 0 {
+		t.Fatalf("None: expected no tool call, got %d", len(resp.ToolCalls))
+	}
+	t.Logf("None: content=%q", resp.Content)
+}
+
+func TestLiveOpenAISpecific(t *testing.T) {
+	resp := send(t, liveOpenAI(t,
+		llm.ToolChoice{Mode: llm.ToolChoiceSpecific, Name: "get_weather"}),
+		"Say hello in one word.")
+	if len(resp.ToolCalls) == 0 || resp.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("Specific: expected get_weather call, got %+v", resp.ToolCalls)
+	}
+	t.Logf("Specific: called %s", resp.ToolCalls[0].Name)
+}

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -52,6 +52,7 @@ type Options struct {
 	presencePenalty   *float64
 	seed              *int64
 	parallelToolCalls *bool
+	toolChoice        *llm.ToolChoice
 	extraBodyFields   map[string]any
 	metadataFields    map[string]string
 }
@@ -146,6 +147,13 @@ func WithSeed(seed int64) Option { return func(o *Options) { o.seed = &seed } }
 // WithParallelToolCalls toggles whether OpenAI returns multiple tool calls in a single response.
 func WithParallelToolCalls(enabled bool) Option {
 	return func(o *Options) { o.parallelToolCalls = &enabled }
+}
+
+// WithToolChoice controls whether and which tool the model may call. It maps to
+// OpenAI's tool_choice field: auto / none / required, or a named-function choice
+// for [llm.ToolChoiceSpecific]. The field is emitted only when tools are sent.
+func WithToolChoice(choice llm.ToolChoice) Option {
+	return func(o *Options) { o.toolChoice = &choice }
 }
 
 // WithRequestJSONField injects an arbitrary top-level field into the request
@@ -400,6 +408,36 @@ func (c *Client) convertTools(
 	return out
 }
 
+// toolChoiceParam maps a vendor-neutral [llm.ToolChoice] to OpenAI's
+// tool_choice union: the "auto"/"none"/"required" string forms, or a named
+// function-tool choice for [llm.ToolChoiceSpecific].
+func toolChoiceParam(
+	choice llm.ToolChoice,
+) openaisdk.ChatCompletionToolChoiceOptionUnionParam {
+	switch choice.Mode {
+	case llm.ToolChoiceNone:
+		return openaisdk.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openaisdk.String("none"),
+		}
+	case llm.ToolChoiceRequired:
+		return openaisdk.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openaisdk.String("required"),
+		}
+	case llm.ToolChoiceSpecific:
+		return openaisdk.ChatCompletionToolChoiceOptionUnionParam{
+			OfFunctionToolChoice: &openaisdk.ChatCompletionNamedToolChoiceParam{
+				Function: openaisdk.ChatCompletionNamedToolChoiceFunctionParam{
+					Name: choice.Name,
+				},
+			},
+		}
+	default:
+		return openaisdk.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openaisdk.String("auto"),
+		}
+	}
+}
+
 func (c *Client) finishReason(reason string) message.FinishReason {
 	switch reason {
 	case "stop":
@@ -425,6 +463,10 @@ func (c *Client) preparedParams(
 
 	if c.options.parallelToolCalls != nil {
 		params.ParallelToolCalls = openaisdk.Bool(*c.options.parallelToolCalls)
+	}
+
+	if c.options.toolChoice != nil && len(tools) > 0 {
+		params.ToolChoice = toolChoiceParam(*c.options.toolChoice)
 	}
 
 	pb := llm.NewParameterBuilder(
@@ -491,12 +533,23 @@ func (c *Client) requestOptions() []option.RequestOption {
 	return opts
 }
 
+// validateToolChoice rejects a malformed tool choice before a request is sent.
+func (c *Client) validateToolChoice() error {
+	if c.options.toolChoice == nil {
+		return nil
+	}
+	return c.options.toolChoice.Validate()
+}
+
 // SendMessages sends a conversation and returns the complete response.
 func (c *Client) SendMessages(
 	ctx context.Context,
 	messages []message.Message,
 	tools []tool.BaseTool,
 ) (*llm.Response, error) {
+	if err := c.validateToolChoice(); err != nil {
+		return nil, err
+	}
 	params := c.preparedParams(
 		c.convertMessages(messages),
 		c.convertTools(tools),
@@ -549,6 +602,9 @@ func (c *Client) StreamResponse(
 	messages []message.Message,
 	tools []tool.BaseTool,
 ) <-chan llm.Event {
+	if err := c.validateToolChoice(); err != nil {
+		return errorEvent(err)
+	}
 	params := c.preparedParams(
 		c.convertMessages(messages),
 		c.convertTools(tools),
@@ -569,6 +625,16 @@ func (c *Client) StreamResponse(
 		}, eventChan)
 	}()
 
+	return eventChan
+}
+
+// errorEvent returns a closed channel carrying a single error event, used to
+// surface pre-flight failures (such as an invalid tool choice) on the streaming
+// API where the method signature has no error return.
+func errorEvent(err error) <-chan llm.Event {
+	eventChan := make(chan llm.Event, 1)
+	eventChan <- llm.Event{Type: types.EventError, Error: err}
+	close(eventChan)
 	return eventChan
 }
 
@@ -768,6 +834,9 @@ func (c *Client) SendMessagesWithStructuredOutput(
 	tools []tool.BaseTool,
 	outputSchema *schema.StructuredOutputInfo,
 ) (*llm.Response, error) {
+	if err := c.validateToolChoice(); err != nil {
+		return nil, err
+	}
 	params := c.preparedParams(
 		c.convertMessages(messages),
 		c.convertTools(tools),
@@ -824,6 +893,9 @@ func (c *Client) StreamResponseWithStructuredOutput(
 	tools []tool.BaseTool,
 	outputSchema *schema.StructuredOutputInfo,
 ) <-chan llm.Event {
+	if err := c.validateToolChoice(); err != nil {
+		return errorEvent(err)
+	}
 	params := c.preparedParams(
 		c.convertMessages(messages),
 		c.convertTools(tools),

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -3,14 +3,138 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/joakimcarlsson/ai/llm"
 	"github.com/joakimcarlsson/ai/message"
 	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/tool"
 )
+
+// stubTool is a no-op BaseTool used to populate the request's tools slice so
+// tool-choice assertions have something to attach to.
+type stubTool struct{ name string }
+
+func (s stubTool) Info() tool.Info {
+	return tool.Info{Name: s.name, Description: "d", Parameters: map[string]any{}}
+}
+
+func (s stubTool) Run(context.Context, tool.Call) (tool.Response, error) {
+	return tool.Response{}, nil
+}
+
+const completionOK = `{"id":"x","object":"chat.completion",` +
+	`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},` +
+	`"finish_reason":"stop"}],` +
+	`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+// TestWireToolChoiceRequired confirms a Required choice serializes to the
+// "required" string form when tools are present.
+func TestWireToolChoiceRequired(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")},
+		[]tool.BaseTool{stubTool{name: "get_weather"}}); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if got, _ := body["tool_choice"].(string); got != "required" {
+		t.Errorf("tool_choice = %v, want %q", body["tool_choice"], "required")
+	}
+}
+
+// TestWireToolChoiceSpecific confirms a Specific choice serializes to the
+// named-function object form naming the tool.
+func TestWireToolChoiceSpecific(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithToolChoice(llm.ToolChoice{
+			Mode: llm.ToolChoiceSpecific,
+			Name: "get_weather",
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")},
+		[]tool.BaseTool{stubTool{name: "get_weather"}}); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	tc, ok := body["tool_choice"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool_choice = %v (%T), want object",
+			body["tool_choice"], body["tool_choice"])
+	}
+	if tc["type"] != "function" {
+		t.Errorf("tool_choice.type = %v, want function", tc["type"])
+	}
+	fn, ok := tc["function"].(map[string]any)
+	if !ok || fn["name"] != "get_weather" {
+		t.Errorf("tool_choice.function = %v, want name=get_weather", tc["function"])
+	}
+}
+
+// TestWireToolChoiceOmittedWithoutTools confirms no tool_choice field is emitted
+// when the tools slice is empty.
+func TestWireToolChoiceOmittedWithoutTools(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if _, present := body["tool_choice"]; present {
+		t.Errorf("tool_choice should be omitted with no tools, got %v",
+			body["tool_choice"])
+	}
+}
+
+// TestToolChoiceSpecificEmptyNameRejected confirms a Specific choice with no
+// name is rejected before any request is sent.
+func TestToolChoiceSpecificEmptyNameRejected(t *testing.T) {
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceSpecific}),
+	)
+
+	_, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")},
+		[]tool.BaseTool{stubTool{name: "get_weather"}})
+	if !errors.Is(err, llm.ErrToolChoiceNameRequired) {
+		t.Fatalf("expected ErrToolChoiceNameRequired, got %v", err)
+	}
+}
 
 // TestPreparedParamsStopSequencesArray verifies that all provided stop
 // sequences are sent as an array (OfStringArray), not just the first one.

--- a/llm/tool_choice.go
+++ b/llm/tool_choice.go
@@ -1,0 +1,40 @@
+package llm
+
+import "errors"
+
+// ToolChoiceMode controls whether/which tool the model may call.
+type ToolChoiceMode int
+
+// ToolChoiceMode values.
+const (
+	ToolChoiceAuto     ToolChoiceMode = iota // model decides (default)
+	ToolChoiceNone                           // never call a tool
+	ToolChoiceRequired                       // must call some tool
+	ToolChoiceSpecific                       // must call ToolChoice.Name
+)
+
+// ToolChoice is a vendor-neutral description of how the model should use the
+// tools supplied with a request. Vendor packages expose it through a
+// WithToolChoice option and translate it to their provider's wire format.
+type ToolChoice struct {
+	// Mode selects the tool-calling discipline.
+	Mode ToolChoiceMode
+	// Name is the tool the model must call; required when Mode is
+	// [ToolChoiceSpecific] and ignored otherwise.
+	Name string
+}
+
+// ErrToolChoiceNameRequired indicates a [ToolChoiceSpecific] choice was made
+// without a tool name, which would produce a malformed provider request.
+var ErrToolChoiceNameRequired = errors.New(
+	"llm: ToolChoiceSpecific requires a non-empty Name",
+)
+
+// Validate reports whether the tool choice is well-formed. A
+// [ToolChoiceSpecific] choice with an empty Name is rejected.
+func (tc ToolChoice) Validate() error {
+	if tc.Mode == ToolChoiceSpecific && tc.Name == "" {
+		return ErrToolChoiceNameRequired
+	}
+	return nil
+}

--- a/tool/mcp-pool.go
+++ b/tool/mcp-pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"sync"
 
@@ -74,7 +75,7 @@ func (p *mcpClientPool) getClient(
 	case MCPStdio:
 		cmd := exec.Command(config.Command, config.Args...)
 		if len(config.Env) > 0 {
-			cmd.Env = config.Env
+			cmd.Env = append(os.Environ(), config.Env...)
 		}
 		transport = &mcp.CommandTransport{Command: cmd}
 	case MCPSse:

--- a/www/docs/advanced/configuration.md
+++ b/www/docs/advanced/configuration.md
@@ -13,6 +13,7 @@ options.
 
 ```go
 import (
+    "github.com/joakimcarlsson/ai/llm"
     llmopenai "github.com/joakimcarlsson/ai/llm/openai"
     "github.com/joakimcarlsson/ai/model"
 )
@@ -33,8 +34,16 @@ client := llmopenai.NewLLM(
     llmopenai.WithPresencePenalty(0.3),
     llmopenai.WithSeed(42),
     llmopenai.WithParallelToolCalls(false),
+    llmopenai.WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
 )
 ```
+
+`WithToolChoice` controls whether and which tool the model may call. It takes
+the shared `llm.ToolChoice` type — `Mode` is one of `ToolChoiceAuto` (default),
+`ToolChoiceNone`, `ToolChoiceRequired`, or `ToolChoiceSpecific` (which also sets
+`Name`). The field is only emitted when tools are supplied, and is available on
+the OpenAI, Anthropic, and Gemini modules (OpenAI-compatible providers inherit
+it through `llm/openai`).
 
 ### Anthropic
 
@@ -50,6 +59,7 @@ client := llmanthropic.NewLLM(
     llmanthropic.WithBedrock(true),
     llmanthropic.WithDisableCache(),
     llmanthropic.WithReasoningEffort(llmanthropic.ReasoningEffortMedium),
+    llmanthropic.WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
 )
 ```
 
@@ -67,6 +77,7 @@ client := llmgemini.NewLLM(
     llmgemini.WithPresencePenalty(0.3),
     llmgemini.WithSeed(42),
     llmgemini.WithThinkingLevel(llmgemini.ThinkingLevelHigh),
+    llmgemini.WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
 )
 ```
 

--- a/www/docs/providers/llm.md
+++ b/www/docs/providers/llm.md
@@ -91,7 +91,18 @@ llmopenai.WithTopP(0.9)
 llmopenai.WithTopK(40)
 llmopenai.WithStopSequences("STOP", "END")
 llmopenai.WithTimeout(30 * time.Second)
+llmopenai.WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired})
 ```
+
+!!! note "`WithToolChoice`"
+    `WithToolChoice` is shared by the OpenAI, Anthropic, and Gemini modules
+    (OpenAI-compatible providers inherit it through `llm/openai`). It takes the
+    vendor-neutral `llm.ToolChoice` type: `Mode` is `ToolChoiceAuto` (default),
+    `ToolChoiceNone`, `ToolChoiceRequired`, or `ToolChoiceSpecific` with a `Name`.
+    It maps to each provider's native field (`tool_choice` for OpenAI/Anthropic,
+    `toolConfig.functionCallingConfig` for Gemini) and is emitted only when tools
+    are supplied. `ToolChoiceSpecific` with an empty `Name` is rejected before the
+    request is sent.
 
 !!! note "`WithTopK` on the OpenAI client"
     OpenAI's and Azure's own APIs reject `top_k` (HTTP 400), so `llmopenai.WithTopK`


### PR DESCRIPTION
Fixes #184

When Env is set for a stdio MCP config, it was replacing the entire process environment instead of appending to it. This caused Node-based MCPs to fail because PATH and other essential env vars were stripped.

Changed cmd.Env = config.Env to cmd.Env = append(os.Environ(), config.Env...) so user-supplied vars are merged on top of the existing environment.