### PR TITLE
feat: surface provider response id on llm.Response + agent.ChatResponse

### DIFF
--- a/agent/chat.go
+++ b/agent/chat.go
@@ -395,13 +395,14 @@ func (a *Agent) runLoop(
 			}
 
 			chatResp := &ChatResponse{
-				Content:        resp.Content,
-				ToolCalls:      resp.ToolCalls,
-				Usage:          totalUsage,
-				FinishReason:   resp.FinishReason,
-				TotalToolCalls: totalToolCalls,
-				TotalDuration:  time.Since(startTime),
-				TotalTurns:     turns,
+				Content:            resp.Content,
+				ToolCalls:          resp.ToolCalls,
+				Usage:              totalUsage,
+				FinishReason:       resp.FinishReason,
+				ProviderResponseID: resp.ProviderResponseID,
+				TotalToolCalls:     totalToolCalls,
+				TotalDuration:      time.Since(startTime),
+				TotalTurns:         turns,
 			}
 			if activeAgent != a {
 				chatResp.AgentName = findAgentName(a, activeAgent)

--- a/agent/response.go
+++ b/agent/response.go
@@ -23,6 +23,11 @@ type ChatResponse struct {
 	Usage llm.TokenUsage
 	// FinishReason indicates why the agent stopped (end_turn, max_tokens, tool_use, etc.).
 	FinishReason message.FinishReason
+	// ProviderResponseID is the provider-assigned id of the final LLM call in the
+	// agent loop (e.g. OpenAI Responses `response.id`). Callers can feed it back
+	// as the previous-response id to chain server-side state; empty for providers
+	// that don't expose one.
+	ProviderResponseID string
 	// AgentName is the name of the agent that produced this response, set when a handoff occurred.
 	AgentName string
 	// TotalToolCalls is the total number of tool invocations across all iterations.

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -526,18 +526,21 @@ func (a *Agent) runLoopStream(
 			}
 
 			var finishReason message.FinishReason
+			var providerResponseID string
 			if finalResponse != nil {
 				finishReason = finalResponse.FinishReason
+				providerResponseID = finalResponse.ProviderResponseID
 			}
 
 			chatResp := &ChatResponse{
-				Content:        fullContent,
-				ToolCalls:      toolCalls,
-				Usage:          totalUsage,
-				FinishReason:   finishReason,
-				TotalToolCalls: totalToolCalls,
-				TotalDuration:  time.Since(startTime),
-				TotalTurns:     turns,
+				Content:            fullContent,
+				ToolCalls:          toolCalls,
+				Usage:              totalUsage,
+				FinishReason:       finishReason,
+				ProviderResponseID: providerResponseID,
+				TotalToolCalls:     totalToolCalls,
+				TotalDuration:      time.Since(startTime),
+				TotalTurns:         turns,
 			}
 			if activeAgent != a {
 				chatResp.AgentName = findAgentName(a, activeAgent)

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -127,6 +127,11 @@ type Response struct {
 	// ProviderMetadata carries provider-specific structured data from
 	// server-side built-in tools. Keys are namespaced per provider.
 	ProviderMetadata map[string]any
+	// ProviderResponseID is the provider-assigned identifier for this response
+	// (e.g. the OpenAI Responses API `response.id`). Empty for providers that do
+	// not expose one. Callers can feed it back as the previous-response id to
+	// chain server-side conversation state (prompt-cache continuity).
+	ProviderResponseID string
 }
 
 // Event represents a single event in a streaming LLM response.

--- a/llm/openai/responses.go
+++ b/llm/openai/responses.go
@@ -503,11 +503,12 @@ func (c *responsesClient) SendMessages(
 			}
 			content, toolCalls, meta := c.extractOutput(resp)
 			return &llm.Response{
-				Content:          content,
-				ToolCalls:        toolCalls,
-				Usage:            c.usage(resp),
-				FinishReason:     c.finishReason(resp),
-				ProviderMetadata: meta,
+				Content:            content,
+				ToolCalls:          toolCalls,
+				Usage:              c.usage(resp),
+				FinishReason:       c.finishReason(resp),
+				ProviderMetadata:   meta,
+				ProviderResponseID: resp.ID,
 			}, nil
 		},
 	)
@@ -546,6 +547,7 @@ func (c *responsesClient) SendMessagesWithStructuredOutput(
 				StructuredOutput:           &content,
 				UsedNativeStructuredOutput: true,
 				ProviderMetadata:           meta,
+				ProviderResponseID:         resp.ID,
 			}, nil
 		},
 	)
@@ -694,11 +696,12 @@ func (c *responsesClient) runStream(
 						meta = map[string]any{"openai.url_citations": citations}
 					}
 					finalResp := &llm.Response{
-						Content:          contentStr,
-						ToolCalls:        toolCalls,
-						Usage:            c.usage(&event.Response),
-						FinishReason:     c.finishReason(&event.Response),
-						ProviderMetadata: meta,
+						Content:            contentStr,
+						ToolCalls:          toolCalls,
+						Usage:              c.usage(&event.Response),
+						FinishReason:       c.finishReason(&event.Response),
+						ProviderMetadata:   meta,
+						ProviderResponseID: event.Response.ID,
 					}
 					if structured {
 						finalResp.StructuredOutput = &contentStr


### PR DESCRIPTION
Surfaces the provider-assigned response id so callers can chain server-side conversation state (OpenAI Responses `previous_response_id` → prompt-cache continuity) without parsing provider payloads.

## Changes
- `llm.Response.ProviderResponseID` (new field).
- OpenAI Responses client populates it from `response.id` at all three construction sites (non-streaming, structured-output, streaming final).
- Threaded out through `agent.ChatResponse.ProviderResponseID` (chat + stream paths).
- Empty for providers that do not expose one — no behavior change for them.

## Note on design
This adds a dedicated field rather than overloading the existing `ProviderMetadata map[string]any`. A `ProviderMetadata["openai.response_id"]` approach would avoid the new field but still needs the agent-layer threading; happy to switch to that if you prefer keeping `llm.Response` lean.

Builds green for `llm`, `llm/openai`, `agent`. Extracted from the Overtura fork (same source as #181).