### PR TITLE
fix(batch/gemini): recurse into array items + nested object properties in schema converter

### DIFF
--- a/batch/gemini/gemini.go
+++ b/batch/gemini/gemini.go
@@ -518,31 +518,87 @@ func convertToGenaiSchema(
 
 	for key, val := range properties {
 		if propMap, ok := val.(map[string]any); ok {
-			propSchema := &genai.Schema{}
-			if t, ok := propMap["type"].(string); ok {
-				switch t {
-				case "string":
-					propSchema.Type = genai.TypeString
-				case "number":
-					propSchema.Type = genai.TypeNumber
-				case "integer":
-					propSchema.Type = genai.TypeInteger
-				case "boolean":
-					propSchema.Type = genai.TypeBoolean
-				case "array":
-					propSchema.Type = genai.TypeArray
-				case "object":
-					propSchema.Type = genai.TypeObject
-				}
-			}
-			if desc, ok := propMap["description"].(string); ok {
-				propSchema.Description = desc
-			}
-			s.Properties[key] = propSchema
+			s.Properties[key] = convertPropertyToGenaiSchema(propMap)
 		}
 	}
 
 	return s
+}
+
+// convertPropertyToGenaiSchema converts a single JSON-schema property to a
+// genai.Schema, recursing into array items and nested object properties. An
+// `array` without Items, or an `object` without nested Properties, is rejected
+// by the Gemini API ("response_schema.properties[x].items: missing field"), so
+// the conversion must descend rather than emit only the top-level Type.
+func convertPropertyToGenaiSchema(propMap map[string]any) *genai.Schema {
+	s := &genai.Schema{}
+
+	if desc, ok := propMap["description"].(string); ok {
+		s.Description = desc
+	}
+
+	typeStr, ok := propMap["type"].(string)
+	if !ok {
+		s.Type = genai.TypeString
+		return s
+	}
+	s.Type = mapJSONTypeToGenai(typeStr)
+
+	switch typeStr {
+	case "array":
+		if items, ok := propMap["items"].(map[string]any); ok {
+			s.Items = convertPropertyToGenaiSchema(items)
+		}
+	case "object":
+		if props, ok := propMap["properties"].(map[string]any); ok {
+			s.Properties = make(map[string]*genai.Schema, len(props))
+			for k, v := range props {
+				if vm, ok := v.(map[string]any); ok {
+					s.Properties[k] = convertPropertyToGenaiSchema(vm)
+				}
+			}
+		}
+		if req, ok := propMap["required"].([]any); ok {
+			reqStrs := make([]string, 0, len(req))
+			for _, r := range req {
+				if rs, ok := r.(string); ok {
+					reqStrs = append(reqStrs, rs)
+				}
+			}
+			s.Required = reqStrs
+		}
+	}
+
+	if enum, ok := propMap["enum"].([]any); ok {
+		enumStrings := make([]string, 0, len(enum))
+		for _, v := range enum {
+			if str, ok := v.(string); ok {
+				enumStrings = append(enumStrings, str)
+			}
+		}
+		s.Enum = enumStrings
+	}
+
+	return s
+}
+
+func mapJSONTypeToGenai(jsonType string) genai.Type {
+	switch jsonType {
+	case "string":
+		return genai.TypeString
+	case "number":
+		return genai.TypeNumber
+	case "integer":
+		return genai.TypeInteger
+	case "boolean":
+		return genai.TypeBoolean
+	case "array":
+		return genai.TypeArray
+	case "object":
+		return genai.TypeObject
+	default:
+		return genai.TypeString
+	}
 }
 
 func convertGeminiResponse(resp *genai.GenerateContentResponse) *llm.Response {


### PR DESCRIPTION
The batch Gemini `convertToGenaiSchema` set the top-level `Type` for `array`/`object` properties but never populated `Items` (arrays) or nested `Properties` (objects). Gemini rejects such a schema with `response_schema.properties[x].items: missing field`, so any batch request whose tools (or a future response schema) contain an array or nested object fails the whole batch.

## Fix
Recurse via a `convertPropertyToGenaiSchema` helper that descends into array `items` and object `properties` (also carries `enum` and nested `required`). Scalars are unchanged.

Found while running structured-extraction batches over Gemini in the Overtura fork (same source as #181/#186).