### PR TITLE
chore: cascade llm@v0.3.0 to agent and llm/openai

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/agent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.3.0
 	github.com/joakimcarlsson/ai/memory v0.1.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0

--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/llm/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.3.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 	github.com/joakimcarlsson/ai/schema v0.1.0


### PR DESCRIPTION
`llm@v0.3.0` adds `Response.ProviderResponseID` (#186). `llm/openai` populates the field and `agent` reads it into `ChatResponse.ProviderResponseID`, so both **must** `require llm@v0.3.0` — otherwise a consumer resolving the old `llm@v0.1.0` floor via MVS hits a compile error (`unknown field ProviderResponseID`).

- `agent`: `require llm v0.1.0 → v0.3.0`
- `llm/openai`: `require llm v0.1.0 → v0.3.0`

No code changes; both build clean with `GOWORK=off go build ./...`.

Follow-up after merge: tag `agent/v0.3.0`, `llm/openai/v0.3.4` (and `batch/gemini/v0.1.4` for the independent #187 fix).