### PR TITLE
Task/179 llm surface request id and response headers on response

### DIFF
--- a/agent/chat.go
+++ b/agent/chat.go
@@ -242,7 +242,10 @@ func (a *Agent) Continue(
 	}
 	messages = append(messages, toolMsg)
 
-	if err := a.session.AddMessages(ctx, []message.Message{toolMsg}); err != nil {
+	if err := a.session.AddMessages(
+		ctx,
+		[]message.Message{toolMsg},
+	); err != nil {
 		return nil, err
 	}
 
@@ -384,7 +387,10 @@ func (a *Agent) runLoop(
 				}
 				if resp.Content != "" ||
 					len(resp.ToolCalls) > 0 && !activeAgent.autoExecute {
-					if err := activeAgent.session.AddMessages(ctx, []message.Message{assistantMsg}); err != nil {
+					if err := activeAgent.session.AddMessages(
+						ctx,
+						[]message.Message{assistantMsg},
+					); err != nil {
 						return nil, err
 					}
 				}
@@ -438,12 +444,18 @@ func (a *Agent) runLoop(
 		messages = append(messages, toolMsg)
 
 		if activeAgent.session != nil {
-			if err := activeAgent.session.AddMessages(ctx, []message.Message{assistantMsg, toolMsg}); err != nil {
+			if err := activeAgent.session.AddMessages(
+				ctx,
+				[]message.Message{assistantMsg, toolMsg},
+			); err != nil {
 				return nil, err
 			}
 		}
 
-		if handoff := detectHandoff(resp.ToolCalls, activeAgent.handoffs); handoff != nil {
+		if handoff := detectHandoff(
+			resp.ToolCalls,
+			activeAgent.handoffs,
+		); handoff != nil {
 			activeAgent = handoff.Agent
 			messages, err = rebuildMessagesForHandoff(
 				ctx,

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -64,11 +64,21 @@ func (a *Agent) storeWithDedup(
 	for _, decision := range result.Decisions {
 		switch decision.Event {
 		case memory.DedupEventAdd:
-			if err := a.memory.Store(ctx, a.memoryID, decision.Text, metadata); err != nil {
+			if err := a.memory.Store(
+				ctx,
+				a.memoryID,
+				decision.Text,
+				metadata,
+			); err != nil {
 				return err
 			}
 		case memory.DedupEventUpdate:
-			if err := a.memory.Update(ctx, decision.MemoryID, decision.Text, metadata); err != nil {
+			if err := a.memory.Update(
+				ctx,
+				decision.MemoryID,
+				decision.Text,
+				metadata,
+			); err != nil {
 				return err
 			}
 		case memory.DedupEventDelete:

--- a/agent/messages.go
+++ b/agent/messages.go
@@ -130,7 +130,10 @@ func (a *Agent) buildMessages(
 		messages = append(messages, sysMsg)
 
 		if a.session != nil && len(sessionMessages) == 0 {
-			if err := a.session.AddMessages(ctx, []message.Message{sysMsg}); err != nil {
+			if err := a.session.AddMessages(
+				ctx,
+				[]message.Message{sysMsg},
+			); err != nil {
 				return nil, err
 			}
 		}
@@ -143,7 +146,10 @@ func (a *Agent) buildMessages(
 	messages = append(messages, userMsg)
 
 	if a.session != nil {
-		if err := a.session.AddMessages(ctx, []message.Message{userMsg}); err != nil {
+		if err := a.session.AddMessages(
+			ctx,
+			[]message.Message{userMsg},
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -178,7 +184,10 @@ func (a *Agent) buildMessages(
 
 		if result.SessionUpdate != nil && a.session != nil &&
 			len(result.SessionUpdate.AddMessages) > 0 {
-			if err := a.session.AddMessages(ctx, result.SessionUpdate.AddMessages); err != nil {
+			if err := a.session.AddMessages(
+				ctx,
+				result.SessionUpdate.AddMessages,
+			); err != nil {
 				return nil, fmt.Errorf("failed to save session update: %w", err)
 			}
 		}
@@ -243,7 +252,10 @@ func (a *Agent) buildContinueMessages(
 
 		if result.SessionUpdate != nil && a.session != nil &&
 			len(result.SessionUpdate.AddMessages) > 0 {
-			if err := a.session.AddMessages(ctx, result.SessionUpdate.AddMessages); err != nil {
+			if err := a.session.AddMessages(
+				ctx,
+				result.SessionUpdate.AddMessages,
+			); err != nil {
 				return nil, fmt.Errorf("failed to save session update: %w", err)
 			}
 		}

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -299,7 +299,10 @@ func (a *Agent) ContinueStream(
 		}
 		messages = append(messages, toolMsg)
 
-		if err := a.session.AddMessages(ctx, []message.Message{toolMsg}); err != nil {
+		if err := a.session.AddMessages(
+			ctx,
+			[]message.Message{toolMsg},
+		); err != nil {
 			tracing.SetError(span, err)
 			eventChan <- ChatEvent{Type: types.EventError, Error: err}
 			return
@@ -600,7 +603,10 @@ func (a *Agent) runLoopStream(
 			)
 		}
 
-		if handoff := detectHandoff(toolCalls, activeAgent.handoffs); handoff != nil {
+		if handoff := detectHandoff(
+			toolCalls,
+			activeAgent.handoffs,
+		); handoff != nil {
 			eventChan <- ChatEvent{
 				Type:      types.EventHandoff,
 				AgentName: handoff.Name,

--- a/agent/team_board_tools.go
+++ b/agent/team_board_tools.go
@@ -148,7 +148,11 @@ func (t *completeBoardTaskTool) Run(
 		}
 	}
 
-	if err := tm.TaskBoard.Complete(input.TaskID, assignee, input.Result); err != nil {
+	if err := tm.TaskBoard.Complete(
+		input.TaskID,
+		assignee,
+		input.Result,
+	); err != nil {
 		return tool.NewTextErrorResponse(
 			fmt.Sprintf("failed to complete task: %s", err.Error()),
 		), nil

--- a/agent/team_tools.go
+++ b/agent/team_tools.go
@@ -65,7 +65,10 @@ func (t *spawnTeammateTool) Run(
 	} else {
 		prompt := input.SystemPrompt
 		if prompt == "" {
-			prompt = fmt.Sprintf("You are a teammate named %q. Complete the assigned task and communicate with your team using send_message and read_messages.", input.Name)
+			prompt = fmt.Sprintf(
+				"You are a teammate named %q. Complete the assigned task and communicate with your team using send_message and read_messages.",
+				input.Name,
+			)
 		}
 		teammate = New(t.leadAgent.llm,
 			WithSystemPrompt(prompt),

--- a/batch/gemini/gemini.go
+++ b/batch/gemini/gemini.go
@@ -148,13 +148,23 @@ func (p *Processor) Process(
 	}
 
 	if len(chatRequests) > 0 {
-		if err := p.processChatBatch(ctx, chatRequests, results, chatIdxMap); err != nil {
+		if err := p.processChatBatch(
+			ctx,
+			chatRequests,
+			results,
+			chatIdxMap,
+		); err != nil {
 			return nil, fmt.Errorf("batch: gemini chat batch failed: %w", err)
 		}
 	}
 
 	if len(embedRequests) > 0 {
-		if err := p.processEmbeddingBatch(ctx, embedRequests, results, embedIdxMap); err != nil {
+		if err := p.processEmbeddingBatch(
+			ctx,
+			embedRequests,
+			results,
+			embedIdxMap,
+		); err != nil {
 			return nil, fmt.Errorf(
 				"batch: gemini embedding batch failed: %w",
 				err,
@@ -469,7 +479,10 @@ func convertMessagesToGemini(
 		case message.Tool:
 			for _, tr := range msg.ToolResults() {
 				var respData map[string]any
-				if err := json.Unmarshal([]byte(tr.Content), &respData); err != nil {
+				if err := json.Unmarshal(
+					[]byte(tr.Content),
+					&respData,
+				); err != nil {
 					respData = map[string]any{"result": tr.Content}
 				}
 				contents = append(contents, &genai.Content{

--- a/batch/openai/openai.go
+++ b/batch/openai/openai.go
@@ -252,7 +252,13 @@ func (p *Processor) processBatch(
 	}
 
 	if job.OutputFileID != "" {
-		if err := p.parseOutputFile(ctx, job.OutputFileID, endpoint, results, idxMap); err != nil {
+		if err := p.parseOutputFile(
+			ctx,
+			job.OutputFileID,
+			endpoint,
+			results,
+			idxMap,
+		); err != nil {
 			return fmt.Errorf("failed to parse output file: %w", err)
 		}
 	}

--- a/embeddings/voyage/voyage.go
+++ b/embeddings/voyage/voyage.go
@@ -51,7 +51,10 @@ func (ev *EmbeddingVector) UnmarshalJSON(data []byte) error {
 				if f, ok := val.(float64); ok {
 					ev.Float32[i] = float32(f)
 				} else {
-					return fmt.Errorf("mixed types in float embedding at index %d", i)
+					return fmt.Errorf(
+						"mixed types in float embedding at index %d",
+						i,
+					)
 				}
 			}
 			ev.DataType = "float32"
@@ -61,7 +64,10 @@ func (ev *EmbeddingVector) UnmarshalJSON(data []byte) error {
 				if f, ok := val.(float32); ok {
 					ev.Float32[i] = f
 				} else {
-					return fmt.Errorf("mixed types in float32 embedding at index %d", i)
+					return fmt.Errorf(
+						"mixed types in float32 embedding at index %d",
+						i,
+					)
 				}
 			}
 			ev.DataType = "float32"

--- a/examples/llm/stream-structured-output/main.go
+++ b/examples/llm/stream-structured-output/main.go
@@ -66,7 +66,10 @@ func main() {
 	}
 
 	var report bugReport
-	if err := json.Unmarshal([]byte(*finalResp.StructuredOutput), &report); err != nil {
+	if err := json.Unmarshal(
+		[]byte(*finalResp.StructuredOutput),
+		&report,
+	); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("[%s] parsed: %+v\n", provider, report)

--- a/examples/llm/structured-output/main.go
+++ b/examples/llm/structured-output/main.go
@@ -54,7 +54,10 @@ func main() {
 	}
 
 	var summary taskSummary
-	if err := json.Unmarshal([]byte(*resp.StructuredOutput), &summary); err != nil {
+	if err := json.Unmarshal(
+		[]byte(*resp.StructuredOutput),
+		&summary,
+	); err != nil {
 		log.Fatal(err)
 	}
 

--- a/llm/anthropic/anthropic.go
+++ b/llm/anthropic/anthropic.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
@@ -554,16 +555,18 @@ func (c *Client) SendMessages(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
+			var raw *http.Response
 			anthropicResponse, err := c.client.Messages.New(
 				ctx,
 				preparedMessages,
+				option.WithResponseInto(&raw),
 			)
 			if err != nil {
 				return nil, wrapError(err)
 			}
 
 			content, meta := c.extractContent(*anthropicResponse)
-			return &llm.Response{
+			resp := &llm.Response{
 				Content:   content,
 				ToolCalls: c.toolCalls(*anthropicResponse),
 				Usage:     c.usage(*anthropicResponse),
@@ -571,9 +574,21 @@ func (c *Client) SendMessages(
 					string(anthropicResponse.StopReason),
 				),
 				ProviderMetadata: meta,
-			}, nil
+			}
+			applyResponseHeaders(resp, raw)
+			return resp, nil
 		},
 	)
+}
+
+// applyResponseHeaders lifts the provider request id and selected response
+// headers from a captured raw HTTP response onto resp. It is a no-op when the
+// response was not captured (raw is nil).
+func applyResponseHeaders(resp *llm.Response, raw *http.Response) {
+	if resp == nil || raw == nil {
+		return
+	}
+	resp.RequestID, resp.ResponseHeaders = llm.SelectResponseHeaders(raw.Header)
 }
 
 // StreamResponse sends a conversation and returns a channel of streaming events.
@@ -609,7 +624,10 @@ func (c *Client) runStream(
 	eventChan chan<- llm.Event,
 	structured bool,
 ) error {
-	anthropicStream := c.client.Messages.NewStreaming(ctx, preparedMessages)
+	var raw *http.Response
+	anthropicStream := c.client.Messages.NewStreaming(
+		ctx, preparedMessages, option.WithResponseInto(&raw),
+	)
 	accumulatedMessage := anthropicsdk.Message{}
 
 	currentBlockType := ""
@@ -689,6 +707,7 @@ func (c *Client) runStream(
 				FinishReason:     c.finishReason(string(accumulatedMessage.StopReason)),
 				ProviderMetadata: meta,
 			}
+			applyResponseHeaders(resp, raw)
 			if structured {
 				resp.StructuredOutput = &content
 				resp.UsedNativeStructuredOutput = true
@@ -798,16 +817,18 @@ func (c *Client) SendMessagesWithStructuredOutput(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
+			var raw *http.Response
 			anthropicResponse, err := c.client.Messages.New(
 				ctx,
 				preparedMessages,
+				option.WithResponseInto(&raw),
 			)
 			if err != nil {
 				return nil, wrapError(err)
 			}
 
 			content, meta := c.extractContent(*anthropicResponse)
-			return &llm.Response{
+			resp := &llm.Response{
 				Content:   content,
 				ToolCalls: c.toolCalls(*anthropicResponse),
 				Usage:     c.usage(*anthropicResponse),
@@ -817,7 +838,9 @@ func (c *Client) SendMessagesWithStructuredOutput(
 				StructuredOutput:           &content,
 				UsedNativeStructuredOutput: true,
 				ProviderMetadata:           meta,
-			}, nil
+			}
+			applyResponseHeaders(resp, raw)
+			return resp, nil
 		},
 	)
 }

--- a/llm/anthropic/anthropic.go
+++ b/llm/anthropic/anthropic.go
@@ -311,7 +311,10 @@ func (c *Client) convertMessages(
 
 			for _, toolCall := range msg.ToolCalls() {
 				var inputMap map[string]any
-				if err := json.Unmarshal([]byte(toolCall.Input), &inputMap); err != nil {
+				if err := json.Unmarshal(
+					[]byte(toolCall.Input),
+					&inputMap,
+				); err != nil {
 					continue
 				}
 				blocks = append(blocks, anthropicsdk.NewToolUseBlock(
@@ -701,10 +704,12 @@ func (c *Client) runStream(
 		case anthropicsdk.MessageStopEvent:
 			content, meta := c.extractContent(accumulatedMessage)
 			resp := &llm.Response{
-				Content:          content,
-				ToolCalls:        c.toolCalls(accumulatedMessage),
-				Usage:            c.usage(accumulatedMessage),
-				FinishReason:     c.finishReason(string(accumulatedMessage.StopReason)),
+				Content:   content,
+				ToolCalls: c.toolCalls(accumulatedMessage),
+				Usage:     c.usage(accumulatedMessage),
+				FinishReason: c.finishReason(
+					string(accumulatedMessage.StopReason),
+				),
 				ProviderMetadata: meta,
 			}
 			applyResponseHeaders(resp, raw)

--- a/llm/anthropic/anthropic_test.go
+++ b/llm/anthropic/anthropic_test.go
@@ -17,7 +17,11 @@ import (
 type stubTool struct{ name string }
 
 func (s stubTool) Info() tool.Info {
-	return tool.Info{Name: s.name, Description: "d", Parameters: map[string]any{}}
+	return tool.Info{
+		Name:        s.name,
+		Description: "d",
+		Parameters:  map[string]any{},
+	}
 }
 
 func (s stubTool) Run(context.Context, tool.Call) (tool.Response, error) {
@@ -34,7 +38,11 @@ func optsFrom(opts ...Option) Options {
 
 // toolChoiceBody builds a request for the given options and one tool, then
 // returns the marshaled request body as a generic map for wire assertions.
-func toolChoiceBody(t *testing.T, tools []tool.BaseTool, opts ...Option) map[string]any {
+func toolChoiceBody(
+	t *testing.T,
+	tools []tool.BaseTool,
+	opts ...Option,
+) map[string]any {
 	t.Helper()
 	c := &Client{options: optsFrom(opts...)}
 	params := c.preparedMessages(nil, c.convertTools(tools), nil)

--- a/llm/anthropic/live_toolchoice_test.go
+++ b/llm/anthropic/live_toolchoice_test.go
@@ -20,7 +20,10 @@ func (liveWeatherTool) Info() tool.Info {
 		Name:        "get_weather",
 		Description: "Get the current weather for a city.",
 		Parameters: map[string]any{
-			"city": map[string]any{"type": "string", "description": "City name"},
+			"city": map[string]any{
+				"type":        "string",
+				"description": "City name",
+			},
 		},
 		Required: []string{"city"},
 	}
@@ -55,12 +58,19 @@ func send(t *testing.T, c llm.LLM, prompt string) *llm.Response {
 }
 
 func TestLiveAnthropicRequired(t *testing.T) {
-	resp := send(t, liveAnthropic(t, llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
-		"Say hello in one word.")
+	resp := send(
+		t,
+		liveAnthropic(t, llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+		"Say hello in one word.",
+	)
 	if len(resp.ToolCalls) == 0 {
 		t.Fatalf("Required: expected a tool call, got content=%q", resp.Content)
 	}
-	t.Logf("Required: tool calls=%d first=%s", len(resp.ToolCalls), resp.ToolCalls[0].Name)
+	t.Logf(
+		"Required: tool calls=%d first=%s",
+		len(resp.ToolCalls),
+		resp.ToolCalls[0].Name,
+	)
 }
 
 func TestLiveAnthropicNone(t *testing.T) {

--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -198,6 +198,10 @@ func wrapError(err error) error {
 }
 
 // Client implements [llm.LLM] against the Google Gemini API.
+//
+// The genai SDK does not expose the underlying HTTP response, so
+// [llm.Response.RequestID] and [llm.Response.ResponseHeaders] are left empty
+// for this provider.
 type Client struct {
 	options Options
 	client  *genai.Client

--- a/llm/gemini/gemini_tool_choice_test.go
+++ b/llm/gemini/gemini_tool_choice_test.go
@@ -17,7 +17,11 @@ import (
 type stubTool struct{ name string }
 
 func (s stubTool) Info() tool.Info {
-	return tool.Info{Name: s.name, Description: "d", Parameters: map[string]any{}}
+	return tool.Info{
+		Name:        s.name,
+		Description: "d",
+		Parameters:  map[string]any{},
+	}
 }
 
 func (s stubTool) Run(context.Context, tool.Call) (tool.Response, error) {
@@ -32,7 +36,10 @@ func clientWith(opts ...Option) *Client {
 	return &Client{options: o}
 }
 
-func functionCallingConfig(t *testing.T, cfg *genai.GenerateContentConfig) *genai.FunctionCallingConfig {
+func functionCallingConfig(
+	t *testing.T,
+	cfg *genai.GenerateContentConfig,
+) *genai.FunctionCallingConfig {
 	t.Helper()
 	if cfg.ToolConfig == nil || cfg.ToolConfig.FunctionCallingConfig == nil {
 		t.Fatal("expected toolConfig.functionCallingConfig to be set")
@@ -51,7 +58,10 @@ func TestToolChoiceRequired(t *testing.T) {
 		t.Errorf("mode = %q, want ANY", fc.Mode)
 	}
 	if len(fc.AllowedFunctionNames) != 0 {
-		t.Errorf("AllowedFunctionNames = %v, want empty", fc.AllowedFunctionNames)
+		t.Errorf(
+			"AllowedFunctionNames = %v, want empty",
+			fc.AllowedFunctionNames,
+		)
 	}
 }
 
@@ -61,7 +71,10 @@ func TestToolChoiceNone(t *testing.T) {
 		WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceNone}),
 	).buildConfig(nil, []tool.BaseTool{stubTool{name: "get_weather"}})
 
-	if fc := functionCallingConfig(t, cfg); fc.Mode != genai.FunctionCallingConfigModeNone {
+	if fc := functionCallingConfig(
+		t,
+		cfg,
+	); fc.Mode != genai.FunctionCallingConfigModeNone {
 		t.Errorf("mode = %q, want NONE", fc.Mode)
 	}
 }
@@ -80,7 +93,8 @@ func TestToolChoiceSpecific(t *testing.T) {
 	if fc.Mode != genai.FunctionCallingConfigModeAny {
 		t.Errorf("mode = %q, want ANY", fc.Mode)
 	}
-	if len(fc.AllowedFunctionNames) != 1 || fc.AllowedFunctionNames[0] != "get_weather" {
+	if len(fc.AllowedFunctionNames) != 1 ||
+		fc.AllowedFunctionNames[0] != "get_weather" {
 		t.Errorf("AllowedFunctionNames = %v, want [get_weather]",
 			fc.AllowedFunctionNames)
 	}

--- a/llm/gemini/gemini_tool_fixes_test.go
+++ b/llm/gemini/gemini_tool_fixes_test.go
@@ -12,7 +12,9 @@ import (
 func TestGemini_ToolResultRoleIsUser(t *testing.T) {
 	c := &Client{}
 	toolMsg := message.NewMessage(message.Tool, nil)
-	toolMsg.AddToolResult(message.ToolResult{ToolCallID: "1", Name: "search", Content: "result"})
+	toolMsg.AddToolResult(
+		message.ToolResult{ToolCallID: "1", Name: "search", Content: "result"},
+	)
 
 	contents, _ := c.convertMessages([]message.Message{toolMsg})
 	if len(contents) == 0 {
@@ -47,7 +49,11 @@ func TestGemini_ThoughtSignatureReplay(t *testing.T) {
 			if p.FunctionCall != nil {
 				found = true
 				if !bytes.Equal(p.ThoughtSignature, sig) {
-					t.Errorf("replayed ThoughtSignature = %q, want %q", p.ThoughtSignature, sig)
+					t.Errorf(
+						"replayed ThoughtSignature = %q, want %q",
+						p.ThoughtSignature,
+						sig,
+					)
 				}
 			}
 		}
@@ -62,13 +68,18 @@ func TestGemini_ThoughtSignatureReplay(t *testing.T) {
 func TestGemini_NoThoughtSignatureIsClean(t *testing.T) {
 	c := &Client{}
 	asst := message.NewAssistantMessage()
-	asst.AppendToolCalls([]message.ToolCall{{Name: "search", Input: "{}", Type: "function"}})
+	asst.AppendToolCalls(
+		[]message.ToolCall{{Name: "search", Input: "{}", Type: "function"}},
+	)
 
 	contents, _ := c.convertMessages([]message.Message{asst})
 	for _, ct := range contents {
 		for _, p := range ct.Parts {
 			if p.FunctionCall != nil && len(p.ThoughtSignature) != 0 {
-				t.Errorf("expected empty ThoughtSignature, got %q", p.ThoughtSignature)
+				t.Errorf(
+					"expected empty ThoughtSignature, got %q",
+					p.ThoughtSignature,
+				)
 			}
 		}
 	}

--- a/llm/gemini/live_toolchoice_test.go
+++ b/llm/gemini/live_toolchoice_test.go
@@ -20,7 +20,10 @@ func (liveWeatherTool) Info() tool.Info {
 		Name:        "get_weather",
 		Description: "Get the current weather for a city.",
 		Parameters: map[string]any{
-			"city": map[string]any{"type": "string", "description": "City name"},
+			"city": map[string]any{
+				"type":        "string",
+				"description": "City name",
+			},
 		},
 		Required: []string{"city"},
 	}
@@ -60,7 +63,11 @@ func TestLiveGeminiRequired(t *testing.T) {
 	if len(resp.ToolCalls) == 0 {
 		t.Fatalf("Required: expected a tool call, got content=%q", resp.Content)
 	}
-	t.Logf("Required: tool calls=%d first=%s", len(resp.ToolCalls), resp.ToolCalls[0].Name)
+	t.Logf(
+		"Required: tool calls=%d first=%s",
+		len(resp.ToolCalls),
+		resp.ToolCalls[0].Name,
+	)
 }
 
 func TestLiveGeminiNone(t *testing.T) {

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -26,6 +26,8 @@ package llm
 
 import (
 	"context"
+	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -132,6 +134,43 @@ type Response struct {
 	// not expose one. Callers can feed it back as the previous-response id to
 	// chain server-side conversation state (prompt-cache continuity).
 	ProviderResponseID string
+	// RequestID is the provider request id (the x-request-id / request-id
+	// response header) — the first thing provider support asks for when
+	// debugging a bad response. Empty when the provider does not supply one
+	// (e.g. Gemini).
+	RequestID string
+	// ResponseHeaders holds a small allowlist of debugging-relevant response
+	// headers (request id, rate-limit, retry-after) copied from the provider's
+	// HTTP response. Only those headers are retained — never the full set — to
+	// avoid leaking auth-echo headers. Nil when unavailable.
+	ResponseHeaders http.Header
+}
+
+// SelectResponseHeaders extracts the provider request id and a small allowlist
+// of debugging-relevant headers (request id, rate-limit, retry-after) from an
+// HTTP response header set. Vendor packages call it after a successful request
+// to populate [Response.RequestID] and [Response.ResponseHeaders]. Only the
+// allowlisted headers are copied, so callers never surface auth-echo headers.
+// Both results are empty/nil when h carries none of them.
+func SelectResponseHeaders(h http.Header) (requestID string, selected http.Header) {
+	if len(h) == 0 {
+		return "", nil
+	}
+	requestID = h.Get("X-Request-Id")
+	if requestID == "" {
+		requestID = h.Get("Request-Id")
+	}
+	for key, values := range h {
+		lower := strings.ToLower(key)
+		if lower == "x-request-id" || lower == "request-id" ||
+			lower == "retry-after" || strings.Contains(lower, "ratelimit") {
+			if selected == nil {
+				selected = make(http.Header)
+			}
+			selected[key] = append([]string(nil), values...)
+		}
+	}
+	return requestID, selected
 }
 
 // Event represents a single event in a streaming LLM response.

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -152,7 +152,9 @@ type Response struct {
 // to populate [Response.RequestID] and [Response.ResponseHeaders]. Only the
 // allowlisted headers are copied, so callers never surface auth-echo headers.
 // Both results are empty/nil when h carries none of them.
-func SelectResponseHeaders(h http.Header) (requestID string, selected http.Header) {
+func SelectResponseHeaders(
+	h http.Header,
+) (requestID string, selected http.Header) {
 	if len(h) == 0 {
 		return "", nil
 	}

--- a/llm/openai/live_toolchoice_test.go
+++ b/llm/openai/live_toolchoice_test.go
@@ -20,7 +20,10 @@ func (liveWeatherTool) Info() tool.Info {
 		Name:        "get_weather",
 		Description: "Get the current weather for a city.",
 		Parameters: map[string]any{
-			"city": map[string]any{"type": "string", "description": "City name"},
+			"city": map[string]any{
+				"type":        "string",
+				"description": "City name",
+			},
 		},
 		Required: []string{"city"},
 	}
@@ -60,7 +63,11 @@ func TestLiveOpenAIRequired(t *testing.T) {
 	if len(resp.ToolCalls) == 0 {
 		t.Fatalf("Required: expected a tool call, got content=%q", resp.Content)
 	}
-	t.Logf("Required: tool calls=%d first=%s", len(resp.ToolCalls), resp.ToolCalls[0].Name)
+	t.Logf(
+		"Required: tool calls=%d first=%s",
+		len(resp.ToolCalls),
+		resp.ToolCalls[0].Name,
+	)
 }
 
 func TestLiveOpenAINone(t *testing.T) {

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/joakimcarlsson/ai/llm"
@@ -533,6 +534,15 @@ func (c *Client) requestOptions() []option.RequestOption {
 	return opts
 }
 
+// requestOptionsInto returns the per-call request options plus a hook that
+// copies the raw [*http.Response] into raw, so the request id and selected
+// response headers can be lifted onto [llm.Response] after the call.
+func (c *Client) requestOptionsInto(
+	raw **http.Response,
+) []option.RequestOption {
+	return append(c.requestOptions(), option.WithResponseInto(raw))
+}
+
 // validateToolChoice rejects a malformed tool choice before a request is sent.
 func (c *Client) validateToolChoice() error {
 	if c.options.toolChoice == nil {
@@ -562,10 +572,11 @@ func (c *Client) SendMessages(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
+			var raw *http.Response
 			openaiResponse, err := c.client.Chat.Completions.New(
 				ctx,
 				params,
-				c.requestOptions()...)
+				c.requestOptionsInto(&raw)...)
 			if err != nil {
 				return nil, wrapError(err)
 			}
@@ -585,15 +596,27 @@ func (c *Client) SendMessages(
 				finishReason = message.FinishReasonToolUse
 			}
 
-			return &llm.Response{
+			resp := &llm.Response{
 				Content:          content,
 				ToolCalls:        toolCalls,
 				Usage:            c.usage(*openaiResponse),
 				FinishReason:     finishReason,
 				ProviderMetadata: c.providerMetadata(*openaiResponse),
-			}, nil
+			}
+			applyResponseHeaders(resp, raw)
+			return resp, nil
 		},
 	)
+}
+
+// applyResponseHeaders lifts the provider request id and selected response
+// headers from a captured raw HTTP response onto resp. It is a no-op when the
+// response was not captured (raw is nil).
+func applyResponseHeaders(resp *llm.Response, raw *http.Response) {
+	if resp == nil || raw == nil {
+		return
+	}
+	resp.RequestID, resp.ResponseHeaders = llm.SelectResponseHeaders(raw.Header)
 }
 
 // StreamResponse sends a conversation and returns a channel of streaming events.
@@ -644,10 +667,11 @@ func (c *Client) runStream(
 	eventChan chan<- llm.Event,
 	structured bool,
 ) error {
+	var raw *http.Response
 	openaiStream := c.client.Chat.Completions.NewStreaming(
 		ctx,
 		params,
-		c.requestOptions()...)
+		c.requestOptionsInto(&raw)...)
 
 	acc := openaisdk.ChatCompletionAccumulator{}
 	currentContent := ""
@@ -704,6 +728,7 @@ func (c *Client) runStream(
 			FinishReason:     finishReason,
 			ProviderMetadata: c.providerMetadata(acc.ChatCompletion),
 		}
+		applyResponseHeaders(resp, raw)
 		if structured {
 			resp.StructuredOutput = &currentContent
 			resp.UsedNativeStructuredOutput = true
@@ -850,10 +875,11 @@ func (c *Client) SendMessagesWithStructuredOutput(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
+			var raw *http.Response
 			openaiResponse, err := c.client.Chat.Completions.New(
 				ctx,
 				params,
-				c.requestOptions()...)
+				c.requestOptionsInto(&raw)...)
 			if err != nil {
 				return nil, wrapError(err)
 			}
@@ -873,7 +899,7 @@ func (c *Client) SendMessagesWithStructuredOutput(
 				finishReason = message.FinishReasonToolUse
 			}
 
-			return &llm.Response{
+			resp := &llm.Response{
 				Content:                    content,
 				ToolCalls:                  toolCalls,
 				Usage:                      c.usage(*openaiResponse),
@@ -881,7 +907,9 @@ func (c *Client) SendMessagesWithStructuredOutput(
 				StructuredOutput:           &content,
 				UsedNativeStructuredOutput: true,
 				ProviderMetadata:           c.providerMetadata(*openaiResponse),
-			}, nil
+			}
+			applyResponseHeaders(resp, raw)
+			return resp, nil
 		},
 	)
 }

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -20,7 +20,11 @@ import (
 type stubTool struct{ name string }
 
 func (s stubTool) Info() tool.Info {
-	return tool.Info{Name: s.name, Description: "d", Parameters: map[string]any{}}
+	return tool.Info{
+		Name:        s.name,
+		Description: "d",
+		Parameters:  map[string]any{},
+	}
 }
 
 func (s stubTool) Run(context.Context, tool.Call) (tool.Response, error) {
@@ -90,7 +94,10 @@ func TestWireToolChoiceSpecific(t *testing.T) {
 	}
 	fn, ok := tc["function"].(map[string]any)
 	if !ok || fn["name"] != "get_weather" {
-		t.Errorf("tool_choice.function = %v, want name=get_weather", tc["function"])
+		t.Errorf(
+			"tool_choice.function = %v, want name=get_weather",
+			tc["function"],
+		)
 	}
 }
 
@@ -406,7 +413,9 @@ func TestResponseRequestIDAndHeaders(t *testing.T) {
 	if resp.RequestID != "req_test_123" {
 		t.Errorf("RequestID = %q, want %q", resp.RequestID, "req_test_123")
 	}
-	if got := resp.ResponseHeaders.Get("x-ratelimit-remaining-requests"); got != "42" {
+	if got := resp.ResponseHeaders.Get(
+		"x-ratelimit-remaining-requests",
+	); got != "42" {
 		t.Errorf("x-ratelimit-remaining-requests = %q, want %q", got, "42")
 	}
 	if got := resp.ResponseHeaders.Get("x-request-id"); got != "req_test_123" {

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -377,6 +377,46 @@ func TestUsageReasoningAndDeepSeekCache(t *testing.T) {
 	}
 }
 
+// TestResponseRequestIDAndHeaders confirms the provider request id and the
+// allowlisted rate-limit header are surfaced on the response, while a
+// non-allowlisted header (here, an auth echo) is dropped.
+func TestResponseRequestIDAndHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-request-id", "req_test_123")
+			w.Header().Set("x-ratelimit-remaining-requests", "42")
+			w.Header().Set("authorization", "Bearer leak")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, completionOK)
+		}))
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	resp, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if resp.RequestID != "req_test_123" {
+		t.Errorf("RequestID = %q, want %q", resp.RequestID, "req_test_123")
+	}
+	if got := resp.ResponseHeaders.Get("x-ratelimit-remaining-requests"); got != "42" {
+		t.Errorf("x-ratelimit-remaining-requests = %q, want %q", got, "42")
+	}
+	if got := resp.ResponseHeaders.Get("x-request-id"); got != "req_test_123" {
+		t.Errorf("x-request-id header = %q, want %q", got, "req_test_123")
+	}
+	if got := resp.ResponseHeaders.Get("authorization"); got != "" {
+		t.Errorf("authorization should not be retained, got %q", got)
+	}
+}
+
 // newCompletionServer returns a test server that captures the request body into
 // capture (when non-nil) and replies with the given chat-completion JSON.
 func newCompletionServer(

--- a/llm/openai/responses.go
+++ b/llm/openai/responses.go
@@ -682,7 +682,9 @@ func (c *responsesClient) runStream(
 					}
 
 				case "response.output_text.annotation.added":
-					if cit, ok := urlCitationFromAnnotation(event.Annotation); ok {
+					if cit, ok := urlCitationFromAnnotation(
+						event.Annotation,
+					); ok {
 						citations = append(citations, cit)
 					}
 

--- a/llm/openai/responses.go
+++ b/llm/openai/responses.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -497,19 +498,24 @@ func (c *responsesClient) SendMessages(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
-			resp, err := c.client.Responses.New(ctx, params)
+			var raw *http.Response
+			resp, err := c.client.Responses.New(
+				ctx, params, option.WithResponseInto(&raw),
+			)
 			if err != nil {
 				return nil, wrapError(err)
 			}
 			content, toolCalls, meta := c.extractOutput(resp)
-			return &llm.Response{
+			out := &llm.Response{
 				Content:            content,
 				ToolCalls:          toolCalls,
 				Usage:              c.usage(resp),
 				FinishReason:       c.finishReason(resp),
 				ProviderMetadata:   meta,
 				ProviderResponseID: resp.ID,
-			}, nil
+			}
+			applyResponseHeaders(out, raw)
+			return out, nil
 		},
 	)
 }
@@ -534,12 +540,15 @@ func (c *responsesClient) SendMessagesWithStructuredOutput(
 		ctx,
 		RetryConfig(),
 		func() (*llm.Response, error) {
-			resp, err := c.client.Responses.New(ctx, params)
+			var raw *http.Response
+			resp, err := c.client.Responses.New(
+				ctx, params, option.WithResponseInto(&raw),
+			)
 			if err != nil {
 				return nil, wrapError(err)
 			}
 			content, toolCalls, meta := c.extractOutput(resp)
-			return &llm.Response{
+			out := &llm.Response{
 				Content:                    content,
 				ToolCalls:                  toolCalls,
 				Usage:                      c.usage(resp),
@@ -548,7 +557,9 @@ func (c *responsesClient) SendMessagesWithStructuredOutput(
 				UsedNativeStructuredOutput: true,
 				ProviderMetadata:           meta,
 				ProviderResponseID:         resp.ID,
-			}, nil
+			}
+			applyResponseHeaders(out, raw)
+			return out, nil
 		},
 	)
 }
@@ -615,7 +626,10 @@ func (c *responsesClient) runStream(
 		defer cancel()
 
 		llm.ExecuteStreamWithRetry(ctx, RetryConfig(), func() error {
-			stream := c.client.Responses.NewStreaming(ctx, params)
+			var raw *http.Response
+			stream := c.client.Responses.NewStreaming(
+				ctx, params, option.WithResponseInto(&raw),
+			)
 			var content strings.Builder
 			var citations []map[string]any
 			pendingCalls := map[string]*streamingFunctionCall{}
@@ -703,6 +717,7 @@ func (c *responsesClient) runStream(
 						ProviderMetadata:   meta,
 						ProviderResponseID: event.Response.ID,
 					}
+					applyResponseHeaders(finalResp, raw)
 					if structured {
 						finalResp.StructuredOutput = &contentStr
 						finalResp.UsedNativeStructuredOutput = true

--- a/llm/xai/responses.go
+++ b/llm/xai/responses.go
@@ -651,7 +651,9 @@ func (c *xaiResponsesClient) runStream(
 					}
 
 				case "response.output_text.annotation.added":
-					if cit, ok := urlCitationFromAnnotation(event.Annotation); ok {
+					if cit, ok := urlCitationFromAnnotation(
+						event.Annotation,
+					); ok {
 						citations = append(citations, cit)
 					}
 

--- a/memory/pgvector/memory.go
+++ b/memory/pgvector/memory.go
@@ -213,7 +213,10 @@ func scanEntries(rows *sql.Rows) ([]memory.Entry, error) {
 		entry.CreatedAt = createdAt
 
 		if metadataJSON.Valid && metadataJSON.String != "" {
-			if err := json.Unmarshal([]byte(metadataJSON.String), &entry.Metadata); err != nil {
+			if err := json.Unmarshal(
+				[]byte(metadataJSON.String),
+				&entry.Metadata,
+			); err != nil {
 				return nil, err
 			}
 		}

--- a/memory/sqlite/session.go
+++ b/memory/sqlite/session.go
@@ -133,7 +133,10 @@ func (s *sqliteSession) GetMessages(
 			) sub ORDER BY id ASC`, table)
 		args = []any{s.id, *limit}
 	} else {
-		query = fmt.Sprintf("SELECT parts FROM %s WHERE session_id = ? ORDER BY id ASC", table)
+		query = fmt.Sprintf(
+			"SELECT parts FROM %s WHERE session_id = ? ORDER BY id ASC",
+			table,
+		)
 		args = []any{s.id}
 	}
 

--- a/memory/tools.go
+++ b/memory/tools.go
@@ -235,7 +235,12 @@ func (t *replaceMemoryTool) Run(
 		metadata["category"] = input.Category
 	}
 
-	if err := t.store.Update(ctx, input.MemoryID, input.Fact, metadata); err != nil {
+	if err := t.store.Update(
+		ctx,
+		input.MemoryID,
+		input.Fact,
+		metadata,
+	); err != nil {
 		return tool.NewTextErrorResponse(
 			"failed to replace memory: " + err.Error(),
 		), nil

--- a/message/marshal.go
+++ b/message/marshal.go
@@ -85,7 +85,11 @@ func MarshalMessages(messages []BaseMessage) ([]byte, error) {
 			msgType = "multimodal"
 			data, err = json.Marshal(m)
 		default:
-			return nil, fmt.Errorf("unknown message type at index %d: %T", i, msg)
+			return nil, fmt.Errorf(
+				"unknown message type at index %d: %T",
+				i,
+				msg,
+			)
 		}
 
 		if err != nil {

--- a/stt/deepgram/deepgram.go
+++ b/stt/deepgram/deepgram.go
@@ -515,7 +515,10 @@ func runWriter(
 			<-done
 			return
 		case <-keepalive.C:
-			if err := send(websocket.TextMessage, []byte(`{"type":"KeepAlive"}`)); err != nil {
+			if err := send(
+				websocket.TextMessage,
+				[]byte(`{"type":"KeepAlive"}`),
+			); err != nil {
 				out <- stt.StreamResult{Error: err}
 				_ = conn.Close()
 				<-done

--- a/stt/elevenlabs/elevenlabs.go
+++ b/stt/elevenlabs/elevenlabs.go
@@ -245,11 +245,17 @@ func (c *Client) Transcribe(
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 
-	if err := writer.WriteField("model_id", c.options.model.APIModel); err != nil {
+	if err := writer.WriteField(
+		"model_id",
+		c.options.model.APIModel,
+	); err != nil {
 		return nil, fmt.Errorf("failed to write model_id field: %w", err)
 	}
 	if opts.Language != "" {
-		if err := writer.WriteField("language_code", opts.Language); err != nil {
+		if err := writer.WriteField(
+			"language_code",
+			opts.Language,
+		); err != nil {
 			return nil, fmt.Errorf(
 				"failed to write language_code field: %w",
 				err,
@@ -262,7 +268,10 @@ func (c *Client) Transcribe(
 		}
 	}
 	if c.options.numSpeakers != nil {
-		if err := writer.WriteField("num_speakers", fmt.Sprintf("%d", *c.options.numSpeakers)); err != nil {
+		if err := writer.WriteField(
+			"num_speakers",
+			fmt.Sprintf("%d", *c.options.numSpeakers),
+		); err != nil {
 			return nil, fmt.Errorf(
 				"failed to write num_speakers field: %w",
 				err,
@@ -274,7 +283,10 @@ func (c *Client) Transcribe(
 	if c.options.timestampGranularity != "" {
 		granularity = c.options.timestampGranularity
 	}
-	if err := writer.WriteField("timestamps_granularity", granularity); err != nil {
+	if err := writer.WriteField(
+		"timestamps_granularity",
+		granularity,
+	); err != nil {
 		return nil, fmt.Errorf("failed to write timestamps field: %w", err)
 	}
 

--- a/tests/agent/confirmation_test.go
+++ b/tests/agent/confirmation_test.go
@@ -190,7 +190,11 @@ func TestConfirmation_RequestFromWithinTool(t *testing.T) {
 	inToolTool := &simpleTool{
 		name: "risky",
 		run: func(ctx context.Context, _ tool.Call) (tool.Response, error) {
-			if err := tool.RequestConfirmation(ctx, "about to do something risky", map[string]string{"action": "delete"}); err != nil {
+			if err := tool.RequestConfirmation(
+				ctx,
+				"about to do something risky",
+				map[string]string{"action": "delete"},
+			); err != nil {
 				return tool.Response{}, err
 			}
 			return tool.NewTextResponse("proceeded"), nil
@@ -237,7 +241,11 @@ func TestConfirmation_RequestFromWithinTool_Rejected(t *testing.T) {
 	inToolTool := &simpleTool{
 		name: "risky",
 		run: func(ctx context.Context, _ tool.Call) (tool.Response, error) {
-			if err := tool.RequestConfirmation(ctx, "risky op", nil); err != nil {
+			if err := tool.RequestConfirmation(
+				ctx,
+				"risky op",
+				nil,
+			); err != nil {
 				return tool.Response{}, err
 			}
 			return tool.NewTextResponse("should not reach"), nil
@@ -548,7 +556,11 @@ func TestConfirmation_RequestFromWithinTool_NoProvider(t *testing.T) {
 	inToolTool := &simpleTool{
 		name: "risky",
 		run: func(ctx context.Context, _ tool.Call) (tool.Response, error) {
-			if err := tool.RequestConfirmation(ctx, "risky op", nil); err != nil {
+			if err := tool.RequestConfirmation(
+				ctx,
+				"risky op",
+				nil,
+			); err != nil {
 				return tool.Response{}, err
 			}
 			executed = true

--- a/tool/functiontool/functiontool.go
+++ b/tool/functiontool/functiontool.go
@@ -58,7 +58,10 @@ func (ft *funcTool) Run(
 	if ft.paramType != nil {
 		paramPtr := reflect.New(ft.paramType)
 		if call.Input != "" {
-			if err := json.Unmarshal([]byte(call.Input), paramPtr.Interface()); err != nil {
+			if err := json.Unmarshal(
+				[]byte(call.Input),
+				paramPtr.Interface(),
+			); err != nil {
 				return tool.NewTextErrorResponse(
 					"invalid input: " + err.Error(),
 				), nil

--- a/tts/elevenlabs/elevenlabs.go
+++ b/tts/elevenlabs/elevenlabs.go
@@ -312,7 +312,9 @@ func (c *Client) generateStandard(
 	}
 
 	charCount := int64(0)
-	if charCountStr := resp.Header.Get("x-character-count"); charCountStr != "" {
+	if charCountStr := resp.Header.Get(
+		"x-character-count",
+	); charCountStr != "" {
 		if count, err := strconv.ParseInt(charCountStr, 10, 64); err == nil {
 			charCount = count
 		}

--- a/voice/memory.go
+++ b/voice/memory.go
@@ -81,11 +81,21 @@ func (v *Agent) storeWithDedup(
 	for _, decision := range result.Decisions {
 		switch decision.Event {
 		case memory.DedupEventAdd:
-			if err := v.memory.Store(ctx, v.memoryID, decision.Text, metadata); err != nil {
+			if err := v.memory.Store(
+				ctx,
+				v.memoryID,
+				decision.Text,
+				metadata,
+			); err != nil {
 				return err
 			}
 		case memory.DedupEventUpdate:
-			if err := v.memory.Update(ctx, decision.MemoryID, decision.Text, metadata); err != nil {
+			if err := v.memory.Update(
+				ctx,
+				decision.MemoryID,
+				decision.Text,
+				metadata,
+			); err != nil {
 				return err
 			}
 		case memory.DedupEventDelete:

--- a/voice/pipeline.go
+++ b/voice/pipeline.go
@@ -369,7 +369,13 @@ func streamLLMAndSpeak(
 	}
 
 	if len(toolCalls) == 0 && strings.TrimSpace(text) != "" {
-		if err := speakOneShot(ctx, v.tts, strings.TrimSpace(text), emit, ttsAudio); err != nil {
+		if err := speakOneShot(
+			ctx,
+			v.tts,
+			strings.TrimSpace(text),
+			emit,
+			ttsAudio,
+		); err != nil {
 			return text, toolCalls, err
 		}
 	}

--- a/voice/runner.go
+++ b/voice/runner.go
@@ -355,7 +355,10 @@ func loadInitialHistory(
 		return nil, 0, nil
 	}
 	sysMsg := message.NewSystemMessage(v.systemPrompt)
-	if err := v.session.AddMessages(ctx, []message.Message{sysMsg}); err != nil {
+	if err := v.session.AddMessages(
+		ctx,
+		[]message.Message{sysMsg},
+	); err != nil {
 		return nil, 0, err
 	}
 	return []message.Message{sysMsg}, 1, nil


### PR DESCRIPTION
closes #179 

This pull request primarily refactors function calls throughout the codebase to use multi-line formatting for improved readability and maintainability, especially for functions with multiple arguments. Additionally, it introduces enhanced handling of HTTP response metadata for the Anthropic LLM provider, ensuring that response headers and request IDs are captured and accessible. Minor improvements are also made to error messages and test code formatting.