### PR TITLE
feat: inject custom HTTP client across various SDKs for enhanced transport control

### DIFF
--- a/llm/anthropic/anthropic.go
+++ b/llm/anthropic/anthropic.go
@@ -53,6 +53,7 @@ type Options struct {
 	reasoningEffort *ReasoningEffort
 	toolChoice      *llm.ToolChoice
 	builtinTools    []anthropicsdk.ToolUnionParam
+	httpClient      *http.Client
 }
 
 // Option configures Options.
@@ -105,6 +106,16 @@ func WithTimeout(
 // WithBedrock configures the client to talk to Anthropic models hosted on AWS Bedrock.
 func WithBedrock(useBedrock bool) Option {
 	return func(o *Options) { o.useBedrock = useBedrock }
+}
+
+// WithHTTPClient injects a custom *http.Client, threaded into the Anthropic SDK
+// via option.WithHTTPClient. Use it for outbound proxies, custom TLS (private
+// CAs, mTLS), connection-pool tuning, or transport-level instrumentation. A nil
+// client is a no-op, leaving the SDK default client in place. The per-request
+// context timeout from WithTimeout still applies on top of the injected client's
+// transport: the two compose and the shorter deadline wins.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *Options) { o.httpClient = c }
 }
 
 // WithDisableCache disables prompt caching for Anthropic requests.
@@ -234,6 +245,12 @@ func NewLLM(opts ...Option) llm.LLM {
 		clientOpts = append(
 			clientOpts,
 			bedrock.WithLoadDefaultConfig(context.Background()),
+		)
+	}
+	if options.httpClient != nil {
+		clientOpts = append(
+			clientOpts,
+			option.WithHTTPClient(options.httpClient),
 		)
 	}
 

--- a/llm/anthropic/anthropic_test.go
+++ b/llm/anthropic/anthropic_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/joakimcarlsson/ai/llm"
@@ -123,5 +126,60 @@ func TestToolChoiceSpecificEmptyNameRejected(t *testing.T) {
 		[]tool.BaseTool{stubTool{name: "get_weather"}})
 	if !errors.Is(err, llm.ErrToolChoiceNameRequired) {
 		t.Fatalf("expected ErrToolChoiceNameRequired, got %v", err)
+	}
+}
+
+const messageOK = `{"id":"msg_1","type":"message","role":"assistant",` +
+	`"model":"claude","content":[{"type":"text","text":"hi"}],` +
+	`"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+
+// redirectRT rewrites every request to point at the test server's host before
+// delegating to the wrapped transport, and counts the requests it handled. The
+// Anthropic SDK exposes no base-URL option here, so redirecting at the transport
+// is how a test reaches a local httptest server through an injected client.
+type redirectRT struct {
+	base http.RoundTripper
+	host string
+	n    *int
+}
+
+func (c redirectRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	*c.n++
+	r.URL.Scheme = "http"
+	r.URL.Host = c.host
+	return c.base.RoundTrip(r)
+}
+
+// TestWithHTTPClientTransportUsed confirms a client injected via WithHTTPClient
+// handles outgoing requests: the wrapped transport's counter increments, proving
+// the SDK default client was replaced.
+func TestWithHTTPClientTransportUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, messageOK)
+		}))
+	defer srv.Close()
+
+	var n int
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithModel(model.Model{APIModel: "claude"}),
+		WithHTTPClient(&http.Client{
+			Transport: redirectRT{
+				base: http.DefaultTransport,
+				host: srv.Listener.Addr().String(),
+				n:    &n,
+			},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
 	}
 }

--- a/llm/azure/azure.go
+++ b/llm/azure/azure.go
@@ -6,6 +6,7 @@
 package azure
 
 import (
+	"net/http"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ type Options struct {
 	apiVersion            string
 	canReason             *bool
 	supportsStructuredOut *bool
+	httpClient            *http.Client
 }
 
 // Option configures Options.
@@ -110,6 +112,17 @@ func WithReasoning(canReason bool) Option {
 	return func(o *Options) { o.canReason = &canReason }
 }
 
+// WithHTTPClient injects a custom *http.Client, threaded into the OpenAI SDK
+// (and the Azure-auth SDK path) via option.WithHTTPClient. Use it for outbound
+// proxies, custom TLS (private CAs, mTLS), connection-pool tuning, or
+// transport-level instrumentation. A nil client is a no-op, leaving the SDK
+// default client in place. The per-request context timeout from WithTimeout
+// still applies on top of the injected client's transport: the two compose and
+// the shorter deadline wins.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *Options) { o.httpClient = c }
+}
+
 // WithStructuredOutput declares whether the deployed model supports the
 // chat-completions response_format JSON-schema constraint. Use this when
 // the deployment name does not match an entry in [model.AzureModels].
@@ -157,6 +170,12 @@ func NewLLM(opts ...Option) llm.LLM {
 	if options.timeout != nil {
 		openaiOpts = append(openaiOpts, llmopenai.WithTimeout(*options.timeout))
 	}
+	if options.httpClient != nil {
+		openaiOpts = append(
+			openaiOpts,
+			llmopenai.WithHTTPClient(options.httpClient),
+		)
+	}
 
 	// If Azure-specific endpoint+apiVersion aren't set, fall through to plain OpenAI.
 	if options.endpoint == "" || options.apiVersion == "" {
@@ -189,6 +208,9 @@ func NewLLM(opts ...Option) llm.LLM {
 
 	reqOpts := []option.RequestOption{
 		azure.WithEndpoint(options.endpoint, options.apiVersion),
+	}
+	if options.httpClient != nil {
+		reqOpts = append(reqOpts, option.WithHTTPClient(options.httpClient))
 	}
 	if options.apiKey != "" {
 		reqOpts = append(reqOpts, azure.WithAPIKey(options.apiKey))

--- a/llm/azure/azure_test.go
+++ b/llm/azure/azure_test.go
@@ -1,0 +1,62 @@
+package azure
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+)
+
+const completionOK = `{"id":"x","object":"chat.completion",` +
+	`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},` +
+	`"finish_reason":"stop"}],` +
+	`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+// countingRT is an http.RoundTripper that increments a counter on every request
+// before delegating to the wrapped transport, used to prove an injected client's
+// transport actually handled the outgoing request.
+type countingRT struct {
+	http.RoundTripper
+	n *int
+}
+
+func (c countingRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	*c.n++
+	return c.RoundTripper.RoundTrip(r)
+}
+
+// TestWithHTTPClientTransportUsed confirms a client injected via WithHTTPClient
+// handles outgoing requests on the Azure-native SDK path (endpoint + apiVersion
+// set): the wrapped transport's counter increments, proving the SDK default
+// client was replaced.
+func TestWithHTTPClientTransportUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, completionOK)
+		}))
+	defer srv.Close()
+
+	var n int
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithEndpoint(srv.URL),
+		WithAPIVersion("2024-02-01"),
+		WithDeployment("gpt-4o-mini"),
+		WithHTTPClient(&http.Client{
+			Transport: countingRT{RoundTripper: http.DefaultTransport, n: &n},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
+	}
+}

--- a/llm/bedrock/bedrock.go
+++ b/llm/bedrock/bedrock.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -34,6 +35,7 @@ type Options struct {
 	stopSequences []string
 	timeout       *time.Duration
 	disableCache  bool
+	httpClient    *http.Client
 }
 
 // Option configures Options.
@@ -81,6 +83,18 @@ func WithTimeout(
 	timeout time.Duration,
 ) Option {
 	return func(o *Options) { o.timeout = &timeout }
+}
+
+// WithHTTPClient injects a custom *http.Client, passed through to the
+// underlying Anthropic-on-Bedrock client. Use it for outbound proxies, custom
+// TLS (private CAs, mTLS), connection-pool tuning, or transport-level
+// instrumentation. It composes with Bedrock's AWS SigV4 signing, which the SDK
+// applies as request middleware on top of the injected client's transport. A
+// nil client is a no-op, leaving the SDK default client in place. The
+// per-request context timeout from WithTimeout still applies on top of the
+// injected client's transport: the two compose and the shorter deadline wins.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *Options) { o.httpClient = c }
 }
 
 // WithDisableCache disables Anthropic prompt caching. Caching is enabled by
@@ -171,6 +185,12 @@ func newAnthropicChild(options Options) llm.LLM {
 	}
 	if options.timeout != nil {
 		anthOpts = append(anthOpts, llmanthropic.WithTimeout(*options.timeout))
+	}
+	if options.httpClient != nil {
+		anthOpts = append(
+			anthOpts,
+			llmanthropic.WithHTTPClient(options.httpClient),
+		)
 	}
 	return llmanthropic.NewLLM(anthOpts...)
 }

--- a/llm/bedrock/bedrock_test.go
+++ b/llm/bedrock/bedrock_test.go
@@ -1,6 +1,9 @@
 package bedrock
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 func applyOptions(opts ...Option) Options {
 	var o Options
@@ -23,5 +26,20 @@ func TestCachingEnabledByDefault(t *testing.T) {
 func TestWithDisableCacheRespected(t *testing.T) {
 	if !applyOptions(WithDisableCache()).disableCache {
 		t.Fatal("expected WithDisableCache() to set disableCache=true")
+	}
+}
+
+// TestWithHTTPClientStored verifies WithHTTPClient records the client so it can
+// be passed through to the underlying Anthropic-on-Bedrock child. A full
+// transport round-trip is exercised in the anthropic package; here the Bedrock
+// path additionally requires AWS SigV4 signing, so this asserts the wiring at
+// the option level to match the existing option-test convention.
+func TestWithHTTPClientStored(t *testing.T) {
+	c := &http.Client{}
+	if got := applyOptions(WithHTTPClient(c)).httpClient; got != c {
+		t.Fatalf("WithHTTPClient did not store the client: got %v", got)
+	}
+	if applyOptions().httpClient != nil {
+		t.Fatal("httpClient should be nil when WithHTTPClient is not used")
 	}
 }

--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -50,6 +51,7 @@ type Options struct {
 	thinkingBudget   *int32
 	toolChoice       *llm.ToolChoice
 	builtinTools     []*genai.Tool
+	httpClient       *http.Client
 }
 
 // Option configures Options.
@@ -97,6 +99,16 @@ func WithTimeout(
 	timeout time.Duration,
 ) Option {
 	return func(o *Options) { o.timeout = &timeout }
+}
+
+// WithHTTPClient injects a custom *http.Client, set on the genai ClientConfig's
+// HTTPClient field. Use it for outbound proxies, custom TLS (private CAs, mTLS),
+// connection-pool tuning, or transport-level instrumentation. A nil client is a
+// no-op, leaving the SDK default client in place. The per-request context
+// timeout from WithTimeout still applies on top of the injected client's
+// transport: the two compose and the shorter deadline wins.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *Options) { o.httpClient = c }
 }
 
 // WithDisableCache disables response caching.
@@ -214,10 +226,14 @@ func NewLLM(opts ...Option) llm.LLM {
 		o(&options)
 	}
 
-	client, _ := genai.NewClient(context.Background(), &genai.ClientConfig{
+	cfg := &genai.ClientConfig{
 		APIKey:  options.apiKey,
 		Backend: genai.BackendGeminiAPI,
-	})
+	}
+	if options.httpClient != nil {
+		cfg.HTTPClient = options.httpClient
+	}
+	client, _ := genai.NewClient(context.Background(), cfg)
 
 	return llm.WithTracing(
 		&Client{options: options, client: client},

--- a/llm/gemini/gemini_httpclient_test.go
+++ b/llm/gemini/gemini_httpclient_test.go
@@ -1,0 +1,68 @@
+package gemini
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+const generateContentOK = `{"candidates":[{"content":{"role":"model",` +
+	`"parts":[{"text":"hi"}]},"finishReason":"STOP"}],` +
+	`"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,` +
+	`"totalTokenCount":2}}`
+
+// redirectRT rewrites every request to point at the test server's host before
+// delegating to the wrapped transport, and counts the requests it handled. The
+// genai SDK exposes no base-URL option here, so redirecting at the transport is
+// how a test reaches a local httptest server through an injected client.
+type redirectRT struct {
+	base http.RoundTripper
+	host string
+	n    *int
+}
+
+func (c redirectRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	*c.n++
+	r.URL.Scheme = "http"
+	r.URL.Host = c.host
+	return c.base.RoundTrip(r)
+}
+
+// TestWithHTTPClientTransportUsed confirms a client injected via WithHTTPClient
+// handles outgoing requests: the wrapped transport's counter increments, proving
+// the SDK default client was replaced.
+func TestWithHTTPClientTransportUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, generateContentOK)
+		}))
+	defer srv.Close()
+
+	var n int
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithModel(model.Model{APIModel: "gemini-2.0-flash"}),
+		WithHTTPClient(&http.Client{
+			Transport: redirectRT{
+				base: http.DefaultTransport,
+				host: srv.Listener.Addr().String(),
+				n:    &n,
+			},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
+	}
+}

--- a/llm/groq/compound.go
+++ b/llm/groq/compound.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/joakimcarlsson/ai/llm"
@@ -45,6 +46,7 @@ type CompoundOptions struct {
 	baseURL       string
 	extraHeaders  map[string]string
 	builtinTools  []map[string]any
+	httpClient    *http.Client
 }
 
 // CompoundOption configures [CompoundOptions].
@@ -93,6 +95,17 @@ func WithCompoundBaseURL(u string) CompoundOption {
 // WithCompoundExtraHeaders adds custom HTTP headers to API requests.
 func WithCompoundExtraHeaders(h map[string]string) CompoundOption {
 	return func(o *CompoundOptions) { o.extraHeaders = h }
+}
+
+// WithCompoundHTTPClient injects a custom *http.Client, threaded into the
+// OpenAI SDK via option.WithHTTPClient. Use it for outbound proxies, custom TLS
+// (private CAs, mTLS), connection-pool tuning, or transport-level
+// instrumentation. A nil client is a no-op, leaving the SDK default client in
+// place. The per-request context timeout from WithCompoundTimeout still applies
+// on top of the injected client's transport: the two compose and the shorter
+// deadline wins.
+func WithCompoundHTTPClient(c *http.Client) CompoundOption {
+	return func(o *CompoundOptions) { o.httpClient = c }
 }
 
 // WithBrowserSearch enables Groq's browser_search built-in tool. Requires a
@@ -167,6 +180,12 @@ func NewCompoundLLM(opts ...CompoundOption) llm.LLM {
 	}
 	for k, v := range options.extraHeaders {
 		clientOpts = append(clientOpts, option.WithHeader(k, v))
+	}
+	if options.httpClient != nil {
+		clientOpts = append(
+			clientOpts,
+			option.WithHTTPClient(options.httpClient),
+		)
 	}
 
 	return llm.WithTracing(&compoundClient{

--- a/llm/groq/compound_test.go
+++ b/llm/groq/compound_test.go
@@ -1,10 +1,65 @@
 package groq
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
 	openaisdk "github.com/openai/openai-go/v3"
 )
+
+const compoundCompletionOK = `{"id":"x","object":"chat.completion",` +
+	`"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},` +
+	`"finish_reason":"stop"}],` +
+	`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+// countingRT is an http.RoundTripper that increments a counter on every request
+// before delegating to the wrapped transport, used to prove an injected client's
+// transport actually handled the outgoing request.
+type countingRT struct {
+	http.RoundTripper
+	n *int
+}
+
+func (c countingRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	*c.n++
+	return c.RoundTripper.RoundTrip(r)
+}
+
+// TestCompoundWithHTTPClientTransportUsed confirms a client injected via
+// WithCompoundHTTPClient handles outgoing requests: the wrapped transport's
+// counter increments, proving the SDK default client was replaced.
+func TestCompoundWithHTTPClientTransportUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, compoundCompletionOK)
+		}))
+	defer srv.Close()
+
+	var n int
+	client := NewCompoundLLM(
+		WithCompoundAPIKey("test-key"),
+		WithCompoundBaseURL(srv.URL),
+		WithCompoundModel(model.Model{APIModel: "groq/compound"}),
+		WithCompoundHTTPClient(&http.Client{
+			Transport: countingRT{RoundTripper: http.DefaultTransport, n: &n},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
+	}
+}
 
 // TestCompoundPreparedParamsStopSequencesArray verifies that the Groq compound
 // client sends every provided stop sequence as an array, not just the first.

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -56,6 +56,7 @@ type Options struct {
 	toolChoice        *llm.ToolChoice
 	extraBodyFields   map[string]any
 	metadataFields    map[string]string
+	httpClient        *http.Client
 }
 
 // Option configures Options.
@@ -118,6 +119,16 @@ func WithBaseURL(
 // WithExtraHeaders adds custom HTTP headers to API requests.
 func WithExtraHeaders(headers map[string]string) Option {
 	return func(o *Options) { o.extraHeaders = headers }
+}
+
+// WithHTTPClient injects a custom *http.Client, threaded into the OpenAI SDK
+// via option.WithHTTPClient. Use it for outbound proxies, custom TLS (private
+// CAs, mTLS), connection-pool tuning, or transport-level instrumentation. A nil
+// client is a no-op, leaving the SDK default client in place. The per-request
+// context timeout from WithTimeout still applies on top of the injected client's
+// transport: the two compose and the shorter deadline wins.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *Options) { o.httpClient = c }
 }
 
 // WithDisableCache disables response caching for OpenAI requests.
@@ -246,6 +257,12 @@ func NewLLM(opts ...Option) llm.LLM {
 	}
 	for k, v := range options.extraHeaders {
 		clientOpts = append(clientOpts, option.WithHeader(k, v))
+	}
+	if options.httpClient != nil {
+		clientOpts = append(
+			clientOpts,
+			option.WithHTTPClient(options.httpClient),
+		)
 	}
 
 	return llm.WithTracing(&Client{

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -426,6 +426,46 @@ func TestResponseRequestIDAndHeaders(t *testing.T) {
 	}
 }
 
+// countingRT is an http.RoundTripper that increments a counter on every request
+// before delegating to the wrapped transport, used to prove an injected client's
+// transport actually handled the outgoing request.
+type countingRT struct {
+	http.RoundTripper
+	n *int
+}
+
+func (c countingRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	*c.n++
+	return c.RoundTripper.RoundTrip(r)
+}
+
+// TestWithHTTPClientTransportUsed confirms a client injected via WithHTTPClient
+// handles outgoing requests: the wrapped transport's counter increments, proving
+// the SDK default client was replaced.
+func TestWithHTTPClientTransportUsed(t *testing.T) {
+	srv := newCompletionServer(t, nil, completionOK)
+	defer srv.Close()
+
+	var n int
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithHTTPClient(&http.Client{
+			Transport: countingRT{RoundTripper: http.DefaultTransport, n: &n},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
+	}
+}
+
 // newCompletionServer returns a test server that captures the request body into
 // capture (when non-nil) and replies with the given chat-completion JSON.
 func newCompletionServer(

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -389,7 +389,7 @@ func TestUsageReasoningAndDeepSeekCache(t *testing.T) {
 // non-allowlisted header (here, an auth echo) is dropped.
 func TestResponseRequestIDAndHeaders(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
+		func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("x-request-id", "req_test_123")
 			w.Header().Set("x-ratelimit-remaining-requests", "42")
 			w.Header().Set("authorization", "Bearer leak")

--- a/llm/openai/responses.go
+++ b/llm/openai/responses.go
@@ -74,6 +74,7 @@ type ResponsesOptions struct {
 	extraHeaders    map[string]string
 	reasoningEffort *ReasoningEffort
 	builtinTools    []responses.ToolUnionParam
+	httpClient      *http.Client
 }
 
 // ResponsesOption configures [ResponsesOptions].
@@ -117,6 +118,17 @@ func WithResponsesBaseURL(u string) ResponsesOption {
 // WithResponsesExtraHeaders adds custom HTTP headers to API requests.
 func WithResponsesExtraHeaders(h map[string]string) ResponsesOption {
 	return func(o *ResponsesOptions) { o.extraHeaders = h }
+}
+
+// WithResponsesHTTPClient injects a custom *http.Client, threaded into the
+// OpenAI SDK via option.WithHTTPClient. Use it for outbound proxies, custom TLS
+// (private CAs, mTLS), connection-pool tuning, or transport-level
+// instrumentation. A nil client is a no-op, leaving the SDK default client in
+// place. The per-request context timeout from WithResponsesTimeout still
+// applies on top of the injected client's transport: the two compose and the
+// shorter deadline wins.
+func WithResponsesHTTPClient(c *http.Client) ResponsesOption {
+	return func(o *ResponsesOptions) { o.httpClient = c }
 }
 
 // WithResponsesReasoningEffort sets the reasoning effort for o-series / gpt-5
@@ -250,6 +262,9 @@ func NewResponsesLLM(opts ...ResponsesOption) llm.LLM {
 	}
 	for k, v := range options.extraHeaders {
 		clientOpts = append(clientOpts, option.WithHeader(k, v))
+	}
+	if options.httpClient != nil {
+		clientOpts = append(clientOpts, option.WithHTTPClient(options.httpClient))
 	}
 
 	return llm.WithTracing(&responsesClient{

--- a/llm/openai/responses_test.go
+++ b/llm/openai/responses_test.go
@@ -1,0 +1,48 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+const responsesOK = `{"id":"resp_1","object":"response","status":"completed",` +
+	`"output":[{"type":"message","role":"assistant",` +
+	`"content":[{"type":"output_text","text":"hi"}]}],` +
+	`"usage":{"input_tokens":1,"output_tokens":1}}`
+
+// TestResponsesWithHTTPClientTransportUsed confirms a client injected via
+// WithResponsesHTTPClient handles outgoing requests: the wrapped transport's
+// counter increments, proving the SDK default client was replaced.
+func TestResponsesWithHTTPClientTransportUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, responsesOK)
+		}))
+	defer srv.Close()
+
+	var n int
+	client := NewResponsesLLM(
+		WithResponsesAPIKey("test-key"),
+		WithResponsesBaseURL(srv.URL),
+		WithResponsesModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithResponsesHTTPClient(&http.Client{
+			Transport: countingRT{RoundTripper: http.DefaultTransport, n: &n},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
+	}
+}

--- a/llm/vertexai/vertexai.go
+++ b/llm/vertexai/vertexai.go
@@ -5,6 +5,7 @@ package vertexai
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"time"
 
@@ -26,6 +27,7 @@ type Options struct {
 	thinkingLevel *llmgemini.ThinkingLevel
 	project       string
 	location      string
+	httpClient    *http.Client
 }
 
 // Option configures Options.
@@ -73,6 +75,16 @@ func WithThinkingLevel(level llmgemini.ThinkingLevel) Option {
 	return func(o *Options) { o.thinkingLevel = &level }
 }
 
+// WithHTTPClient injects a custom *http.Client, set on the genai ClientConfig's
+// HTTPClient field. Use it for outbound proxies, custom TLS (private CAs, mTLS),
+// connection-pool tuning, or transport-level instrumentation. A nil client is a
+// no-op, leaving the SDK default client in place. The per-request context
+// timeout from WithTimeout still applies on top of the injected client's
+// transport: the two compose and the shorter deadline wins.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *Options) { o.httpClient = c }
+}
+
 // WithProject sets the GCP project ID. Defaults to $VERTEXAI_PROJECT.
 func WithProject(
 	project string,
@@ -109,11 +121,15 @@ func NewLLM(opts ...Option) llm.LLM {
 		location = os.Getenv("VERTEXAI_LOCATION")
 	}
 
-	client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+	cfg := &genai.ClientConfig{
 		Project:  project,
 		Location: location,
 		Backend:  genai.BackendVertexAI,
-	})
+	}
+	if options.httpClient != nil {
+		cfg.HTTPClient = options.httpClient
+	}
+	client, err := genai.NewClient(context.Background(), cfg)
 	if err != nil {
 		// Match the previous nil-on-error behavior; tracing wrapper handles nil safely
 		// because Model() panics only on use, which mirrors the original code path.

--- a/llm/vertexai/vertexai_test.go
+++ b/llm/vertexai/vertexai_test.go
@@ -1,0 +1,71 @@
+package vertexai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+const generateContentOK = `{"candidates":[{"content":{"role":"model",` +
+	`"parts":[{"text":"hi"}]},"finishReason":"STOP"}],` +
+	`"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,` +
+	`"totalTokenCount":2}}`
+
+// redirectRT rewrites every request to point at the test server's host before
+// delegating to the wrapped transport, and counts the requests it handled. The
+// genai SDK exposes no base-URL option here, so redirecting at the transport is
+// how a test reaches a local httptest server through an injected client. Setting
+// HTTPClient also makes the genai client skip Application Default Credentials, so
+// no real GCP auth is needed.
+type redirectRT struct {
+	base http.RoundTripper
+	host string
+	n    *int
+}
+
+func (c redirectRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	*c.n++
+	r.URL.Scheme = "http"
+	r.URL.Host = c.host
+	return c.base.RoundTrip(r)
+}
+
+// TestWithHTTPClientTransportUsed confirms a client injected via WithHTTPClient
+// handles outgoing requests: the wrapped transport's counter increments, proving
+// the SDK default client was replaced.
+func TestWithHTTPClientTransportUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, generateContentOK)
+		}))
+	defer srv.Close()
+
+	var n int
+	client := NewLLM(
+		WithProject("test-project"),
+		WithLocation("us-central1"),
+		WithModel(model.Model{APIModel: "gemini-2.0-flash"}),
+		WithHTTPClient(&http.Client{
+			Transport: redirectRT{
+				base: http.DefaultTransport,
+				host: srv.Listener.Addr().String(),
+				n:    &n,
+			},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
+	}
+}

--- a/llm/xai/responses.go
+++ b/llm/xai/responses.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -76,6 +77,7 @@ type ResponsesOptions struct {
 	extraHeaders    map[string]string
 	reasoningEffort *ReasoningEffort
 	builtinTools    []map[string]any
+	httpClient      *http.Client
 }
 
 // ReasoningEffort controls reasoning depth for xAI reasoning models.
@@ -134,6 +136,17 @@ func WithResponsesExtraHeaders(h map[string]string) ResponsesOption {
 // Note: xAI's grok-4 ignores this parameter.
 func WithResponsesReasoningEffort(e ReasoningEffort) ResponsesOption {
 	return func(o *ResponsesOptions) { o.reasoningEffort = &e }
+}
+
+// WithResponsesHTTPClient injects a custom *http.Client, threaded into the
+// OpenAI SDK via option.WithHTTPClient. Use it for outbound proxies, custom TLS
+// (private CAs, mTLS), connection-pool tuning, or transport-level
+// instrumentation. A nil client is a no-op, leaving the SDK default client in
+// place. The per-request context timeout from WithResponsesTimeout still
+// applies on top of the injected client's transport: the two compose and the
+// shorter deadline wins.
+func WithResponsesHTTPClient(c *http.Client) ResponsesOption {
+	return func(o *ResponsesOptions) { o.httpClient = c }
 }
 
 // WithWebSearch enables the web_search built-in tool.
@@ -234,6 +247,12 @@ func NewResponsesLLM(opts ...ResponsesOption) llm.LLM {
 	}
 	for k, v := range options.extraHeaders {
 		clientOpts = append(clientOpts, option.WithHeader(k, v))
+	}
+	if options.httpClient != nil {
+		clientOpts = append(
+			clientOpts,
+			option.WithHTTPClient(options.httpClient),
+		)
 	}
 
 	return llm.WithTracing(&xaiResponsesClient{

--- a/llm/xai/responses_test.go
+++ b/llm/xai/responses_test.go
@@ -1,0 +1,61 @@
+package xai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+)
+
+const responsesOK = `{"id":"resp_1","object":"response","status":"completed",` +
+	`"output":[{"type":"message","role":"assistant",` +
+	`"content":[{"type":"output_text","text":"hi"}]}],` +
+	`"usage":{"input_tokens":1,"output_tokens":1}}`
+
+// countingRT is an http.RoundTripper that increments a counter on every request
+// before delegating to the wrapped transport, used to prove an injected client's
+// transport actually handled the outgoing request.
+type countingRT struct {
+	http.RoundTripper
+	n *int
+}
+
+func (c countingRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	*c.n++
+	return c.RoundTripper.RoundTrip(r)
+}
+
+// TestResponsesWithHTTPClientTransportUsed confirms a client injected via
+// WithResponsesHTTPClient handles outgoing requests: the wrapped transport's
+// counter increments, proving the SDK default client was replaced.
+func TestResponsesWithHTTPClientTransportUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, responsesOK)
+		}))
+	defer srv.Close()
+
+	var n int
+	client := NewResponsesLLM(
+		WithResponsesAPIKey("test-key"),
+		WithResponsesBaseURL(srv.URL),
+		WithResponsesModel(model.Model{APIModel: "grok-4"}),
+		WithResponsesHTTPClient(&http.Client{
+			Transport: countingRT{RoundTripper: http.DefaultTransport, n: &n},
+		}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if n == 0 {
+		t.Error("injected transport was not used for the request")
+	}
+}


### PR DESCRIPTION
closes #177 