### PR TITLE
feat: add logprobs and logit bias options for OpenAI LLM client; update documentation

### DIFF
--- a/examples/llm/options/main.go
+++ b/examples/llm/options/main.go
@@ -29,6 +29,25 @@ func main() {
 	}
 
 	fmt.Printf("[%s] %s\n", provider, resp.Content)
+
+	// LogProbs is populated by OpenAI (and OpenAI-compatible providers) when
+	// WithLogprobs was set; nil otherwise. Print the first few tokens with
+	// their log probabilities to show the surface.
+	if len(resp.LogProbs) > 0 {
+		fmt.Println("\nper-token log probabilities (first 5):")
+		for _, tok := range resp.LogProbs[:min(5, len(resp.LogProbs))] {
+			fmt.Printf("  %-12q logprob=%.4f\n", tok.Token, tok.LogProb)
+		}
+	}
+
+	// Choices holds every completion when WithN(>1) was used; it stays empty
+	// for a single completion, where the top-level fields above suffice.
+	if len(resp.Choices) > 1 {
+		fmt.Printf("\n%d choices returned:\n", len(resp.Choices))
+		for i, choice := range resp.Choices {
+			fmt.Printf("  [%d] %s\n", i, choice.Content)
+		}
+	}
 }
 
 func newLLM() (llm.LLM, string) {
@@ -64,6 +83,12 @@ func newLLM() (llm.LLM, string) {
 			llmopenai.WithTopP(0.9),
 			llmopenai.WithStopSequences("\n\n"),
 			llmopenai.WithSeed(42),
+			// Per-token log probabilities (top 3 alternatives per position)
+			// surface on resp.LogProbs below. WithN(k) and
+			// WithLogitBias(map[string]int{...}) are the other OpenAI-only
+			// sampling knobs; WithN populates resp.Choices with every
+			// completion.
+			llmopenai.WithLogprobs(3),
 			llmopenai.WithTimeout(timeout),
 		), provider
 	default:

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -118,6 +118,32 @@ func (u *TokenUsage) Add(other TokenUsage) {
 	u.ReasoningTokens += other.ReasoningTokens
 }
 
+// TokenTopLogProb is one of the most likely alternative tokens at a given
+// position, paired with its log probability.
+type TokenTopLogProb struct {
+	Token   string
+	LogProb float64
+}
+
+// TokenLogProb carries the log-probability information for a single output
+// token. Top holds the most likely alternative tokens at that position (the
+// requested top_logprobs), empty when none were requested.
+type TokenLogProb struct {
+	Token   string
+	LogProb float64
+	Top     []TokenTopLogProb
+}
+
+// Choice is one completion among several returned when more than one was
+// requested (see llm/openai.WithN). Each choice carries its own content, finish
+// reason, tool calls, and per-token log probabilities.
+type Choice struct {
+	Content      string
+	FinishReason message.FinishReason
+	ToolCalls    []message.ToolCall
+	LogProbs     []TokenLogProb
+}
+
 // Response represents the complete response from an LLM provider.
 type Response struct {
 	Content                    string
@@ -129,6 +155,16 @@ type Response struct {
 	// ProviderMetadata carries provider-specific structured data from
 	// server-side built-in tools. Keys are namespaced per provider.
 	ProviderMetadata map[string]any
+	// LogProbs holds per-token log probabilities for the primary choice when
+	// log probabilities were requested (llm/openai.WithLogprobs); nil
+	// otherwise. Only OpenAI and OpenAI-compatible providers populate it.
+	LogProbs []TokenLogProb
+	// Choices holds every completion when more than one was requested
+	// (llm/openai.WithN). The top-level Content / FinishReason / ToolCalls /
+	// LogProbs mirror Choices[0]. Empty when a single choice was returned, so
+	// callers use the top-level fields then. Only OpenAI and OpenAI-compatible
+	// providers populate it.
+	Choices []Choice
 	// ProviderResponseID is the provider-assigned identifier for this response
 	// (e.g. the OpenAI Responses API `response.id`). Empty for providers that do
 	// not expose one. Callers can feed it back as the previous-response id to

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -57,6 +57,9 @@ type Options struct {
 	extraBodyFields   map[string]any
 	metadataFields    map[string]string
 	httpClient        *http.Client
+	logitBias         map[string]int
+	topLogprobs       *int
+	n                 *int64
 }
 
 // Option configures Options.
@@ -155,6 +158,35 @@ func WithPresencePenalty(
 
 // WithSeed sets a random seed for deterministic generation.
 func WithSeed(seed int64) Option { return func(o *Options) { o.seed = &seed } }
+
+// WithLogitBias biases the likelihood of specific tokens. The map keys are
+// token IDs in the model's tokenizer (OpenAI's wire shape), and the values are
+// biases from -100 to 100 added to the token logits before sampling: -100 bans
+// a token, 100 forces it. Emitted as logit_bias only when set. OpenAI-only —
+// Gemini and Anthropic do not support it and never receive the field.
+func WithLogitBias(bias map[string]int) Option {
+	return func(o *Options) { o.logitBias = bias }
+}
+
+// WithLogprobs requests per-token log probabilities for the response. It sets
+// logprobs:true and top_logprobs:topLogprobs on the request, asking the model
+// to return up to topLogprobs most-likely alternatives at each position. The
+// result is surfaced on [llm.Response].LogProbs (and on each
+// [llm.Response].Choices entry when WithN is used). OpenAI-only — Gemini and
+// Anthropic do not support it and never receive the field.
+func WithLogprobs(topLogprobs int) Option {
+	return func(o *Options) { o.topLogprobs = &topLogprobs }
+}
+
+// WithN requests n completions for a single prompt, emitted as n on the
+// request. All completions are surfaced on [llm.Response].Choices, while the
+// top-level Content / FinishReason / ToolCalls / LogProbs mirror the first
+// choice. Streaming with n > 1 is not supported. OpenAI-only — Gemini's
+// candidateCount and other providers are out of scope; they never receive the
+// field.
+func WithN(n int) Option {
+	return func(o *Options) { v := int64(n); o.n = &v }
+}
 
 // WithParallelToolCalls toggles whether OpenAI returns multiple tool calls in a single response.
 func WithParallelToolCalls(enabled bool) Option {
@@ -514,6 +546,21 @@ func (c *Client) preparedParams(
 	pb.ApplyInt64Seed(c.options.seed,
 		func(s *int64) { params.Seed = openaisdk.Int(*s) })
 
+	if len(c.options.logitBias) > 0 {
+		bias := make(map[string]int64, len(c.options.logitBias))
+		for token, b := range c.options.logitBias {
+			bias[token] = int64(b)
+		}
+		params.LogitBias = bias
+	}
+	if c.options.topLogprobs != nil {
+		params.Logprobs = openaisdk.Bool(true)
+		params.TopLogprobs = openaisdk.Int(int64(*c.options.topLogprobs))
+	}
+	if c.options.n != nil {
+		params.N = openaisdk.Int(*c.options.n)
+	}
+
 	if c.options.maxTokens > 0 {
 		params.MaxCompletionTokens = openaisdk.Int(c.options.maxTokens)
 	}
@@ -619,6 +666,8 @@ func (c *Client) SendMessages(
 				Usage:            c.usage(*openaiResponse),
 				FinishReason:     finishReason,
 				ProviderMetadata: c.providerMetadata(*openaiResponse),
+				LogProbs:         logProbsForChoice(openaiResponse.Choices[0]),
+				Choices:          c.buildChoices(*openaiResponse),
 			}
 			applyResponseHeaders(resp, raw)
 			return resp, nil
@@ -759,20 +808,81 @@ func (c *Client) runStream(
 func (c *Client) toolCalls(
 	completion openaisdk.ChatCompletion,
 ) []message.ToolCall {
+	if len(completion.Choices) == 0 {
+		return nil
+	}
+	return c.toolCallsForChoice(completion.Choices[0])
+}
+
+// toolCallsForChoice extracts the tool calls from a single completion choice.
+func (c *Client) toolCallsForChoice(
+	choice openaisdk.ChatCompletionChoice,
+) []message.ToolCall {
 	var toolCalls []message.ToolCall
-	if len(completion.Choices) > 0 &&
-		len(completion.Choices[0].Message.ToolCalls) > 0 {
-		for _, call := range completion.Choices[0].Message.ToolCalls {
-			toolCalls = append(toolCalls, message.ToolCall{
-				ID:       call.ID,
-				Name:     call.Function.Name,
-				Input:    call.Function.Arguments,
-				Type:     "function",
-				Finished: true,
-			})
-		}
+	for _, call := range choice.Message.ToolCalls {
+		toolCalls = append(toolCalls, message.ToolCall{
+			ID:       call.ID,
+			Name:     call.Function.Name,
+			Input:    call.Function.Arguments,
+			Type:     "function",
+			Finished: true,
+		})
 	}
 	return toolCalls
+}
+
+// logProbsForChoice maps a choice's logprobs.content block to the
+// vendor-neutral [llm.TokenLogProb] slice. Returns nil when the choice carries
+// no token log probabilities (the option was not requested).
+func logProbsForChoice(
+	choice openaisdk.ChatCompletionChoice,
+) []llm.TokenLogProb {
+	content := choice.Logprobs.Content
+	if len(content) == 0 {
+		return nil
+	}
+	out := make([]llm.TokenLogProb, len(content))
+	for i, tok := range content {
+		lp := llm.TokenLogProb{Token: tok.Token, LogProb: tok.Logprob}
+		if len(tok.TopLogprobs) > 0 {
+			lp.Top = make([]llm.TokenTopLogProb, len(tok.TopLogprobs))
+			for j, alt := range tok.TopLogprobs {
+				lp.Top[j] = llm.TokenTopLogProb{
+					Token:   alt.Token,
+					LogProb: alt.Logprob,
+				}
+			}
+		}
+		out[i] = lp
+	}
+	return out
+}
+
+// buildChoices converts every completion choice into an [llm.Choice]. It
+// returns nil for a single-choice completion (callers rely on the top-level
+// Response fields then); the slice is populated only when n > 1 produced
+// multiple choices.
+func (c *Client) buildChoices(
+	completion openaisdk.ChatCompletion,
+) []llm.Choice {
+	if len(completion.Choices) <= 1 {
+		return nil
+	}
+	choices := make([]llm.Choice, len(completion.Choices))
+	for i, ch := range completion.Choices {
+		toolCalls := c.toolCallsForChoice(ch)
+		finishReason := c.finishReason(string(ch.FinishReason))
+		if len(toolCalls) > 0 {
+			finishReason = message.FinishReasonToolUse
+		}
+		choices[i] = llm.Choice{
+			Content:      ch.Message.Content,
+			FinishReason: finishReason,
+			ToolCalls:    toolCalls,
+			LogProbs:     logProbsForChoice(ch),
+		}
+	}
+	return choices
 }
 
 func (c *Client) usage(completion openaisdk.ChatCompletion) llm.TokenUsage {
@@ -924,6 +1034,8 @@ func (c *Client) SendMessagesWithStructuredOutput(
 				StructuredOutput:           &content,
 				UsedNativeStructuredOutput: true,
 				ProviderMetadata:           c.providerMetadata(*openaiResponse),
+				LogProbs:                   logProbsForChoice(openaiResponse.Choices[0]),
+				Choices:                    c.buildChoices(*openaiResponse),
 			}
 			applyResponseHeaders(resp, raw)
 			return resp, nil

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -466,6 +466,303 @@ func TestWithHTTPClientTransportUsed(t *testing.T) {
 	}
 }
 
+// TestWireLogitBias confirms WithLogitBias emits logit_bias as a token-id ->
+// bias object, and that it is omitted when the option is unset.
+func TestWireLogitBias(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithLogitBias(map[string]int{"50256": -100, "1212": 5}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	bias, ok := body["logit_bias"].(map[string]any)
+	if !ok {
+		t.Fatalf("logit_bias = %v (%T), want object",
+			body["logit_bias"], body["logit_bias"])
+	}
+	if got, _ := bias["50256"].(float64); int(got) != -100 {
+		t.Errorf("logit_bias[50256] = %v, want -100", bias["50256"])
+	}
+	if got, _ := bias["1212"].(float64); int(got) != 5 {
+		t.Errorf("logit_bias[1212] = %v, want 5", bias["1212"])
+	}
+}
+
+// TestWireLogitBiasOmitted confirms logit_bias is absent when WithLogitBias is
+// not set.
+func TestWireLogitBiasOmitted(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if _, present := body["logit_bias"]; present {
+		t.Errorf("logit_bias should be omitted when unset, got %v",
+			body["logit_bias"])
+	}
+}
+
+// TestWireLogprobs confirms WithLogprobs sets logprobs:true and top_logprobs:N
+// on the request body, and that both are omitted when the option is unset.
+func TestWireLogprobs(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithLogprobs(5),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if got, _ := body["logprobs"].(bool); !got {
+		t.Errorf("logprobs = %v, want true", body["logprobs"])
+	}
+	if got, _ := body["top_logprobs"].(float64); int(got) != 5 {
+		t.Errorf("top_logprobs = %v, want 5", body["top_logprobs"])
+	}
+}
+
+// TestWireLogprobsOmitted confirms logprobs/top_logprobs are absent when
+// WithLogprobs is not set.
+func TestWireLogprobsOmitted(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if _, present := body["logprobs"]; present {
+		t.Errorf("logprobs should be omitted when unset, got %v",
+			body["logprobs"])
+	}
+	if _, present := body["top_logprobs"]; present {
+		t.Errorf("top_logprobs should be omitted when unset, got %v",
+			body["top_logprobs"])
+	}
+}
+
+// TestResponseLogProbs confirms a completion carrying a logprobs.content block
+// is mapped onto Response.LogProbs, including the top_logprobs alternatives.
+func TestResponseLogProbs(t *testing.T) {
+	const resp = `{"id":"x","object":"chat.completion","choices":[{"index":0,` +
+		`"message":{"role":"assistant","content":"hi"},"finish_reason":"stop",` +
+		`"logprobs":{"content":[` +
+		`{"token":"hi","logprob":-0.5,"top_logprobs":[` +
+		`{"token":"hi","logprob":-0.5},{"token":"yo","logprob":-1.2}]},` +
+		`{"token":"!","logprob":-0.1,"top_logprobs":[]}]}}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+	srv := newCompletionServer(t, nil, resp)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithLogprobs(2),
+	)
+
+	out, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if len(out.LogProbs) != 2 {
+		t.Fatalf("len(LogProbs) = %d, want 2", len(out.LogProbs))
+	}
+	first := out.LogProbs[0]
+	if first.Token != "hi" || first.LogProb != -0.5 {
+		t.Errorf("LogProbs[0] = %+v, want token=hi logprob=-0.5", first)
+	}
+	if len(first.Top) != 2 {
+		t.Fatalf("len(LogProbs[0].Top) = %d, want 2", len(first.Top))
+	}
+	if first.Top[1].Token != "yo" || first.Top[1].LogProb != -1.2 {
+		t.Errorf("LogProbs[0].Top[1] = %+v, want token=yo logprob=-1.2",
+			first.Top[1])
+	}
+}
+
+// TestResponseLogProbsNilWhenAbsent confirms Response.LogProbs is nil when the
+// completion carries no logprobs block.
+func TestResponseLogProbsNilWhenAbsent(t *testing.T) {
+	srv := newCompletionServer(t, nil, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	out, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if out.LogProbs != nil {
+		t.Errorf("LogProbs = %v, want nil", out.LogProbs)
+	}
+}
+
+// TestWireN confirms WithN emits n on the request body, and that it is omitted
+// when the option is unset.
+func TestWireN(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithN(3),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if got, _ := body["n"].(float64); int(got) != 3 {
+		t.Errorf("n = %v, want 3", body["n"])
+	}
+}
+
+// TestWireNOmitted confirms n is absent when WithN is not set.
+func TestWireNOmitted(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	if _, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil); err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if _, present := body["n"]; present {
+		t.Errorf("n should be omitted when unset, got %v", body["n"])
+	}
+}
+
+// TestResponseChoices confirms a completion with multiple choices populates
+// Response.Choices, with the top-level fields mirroring choice 0.
+func TestResponseChoices(t *testing.T) {
+	const resp = `{"id":"x","object":"chat.completion","choices":[` +
+		`{"index":0,"message":{"role":"assistant","content":"first"},` +
+		`"finish_reason":"stop"},` +
+		`{"index":1,"message":{"role":"assistant","content":"second"},` +
+		`"finish_reason":"length"},` +
+		`{"index":2,"message":{"role":"assistant","content":"third"},` +
+		`"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":3,"total_tokens":4}}`
+
+	srv := newCompletionServer(t, nil, resp)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithN(3),
+	)
+
+	out, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if len(out.Choices) != 3 {
+		t.Fatalf("len(Choices) = %d, want 3", len(out.Choices))
+	}
+	if out.Content != out.Choices[0].Content || out.Content != "first" {
+		t.Errorf("Content = %q, want choice 0 %q", out.Content,
+			out.Choices[0].Content)
+	}
+	if out.FinishReason != out.Choices[0].FinishReason {
+		t.Errorf("FinishReason = %q, want choice 0 %q", out.FinishReason,
+			out.Choices[0].FinishReason)
+	}
+	if out.Choices[1].Content != "second" {
+		t.Errorf("Choices[1].Content = %q, want second", out.Choices[1].Content)
+	}
+	if out.Choices[1].FinishReason != message.FinishReasonMaxTokens {
+		t.Errorf("Choices[1].FinishReason = %q, want max-tokens",
+			out.Choices[1].FinishReason)
+	}
+}
+
+// TestResponseChoicesEmptyForSingleChoice confirms Response.Choices stays empty
+// for a single-choice completion so callers use the top-level fields.
+func TestResponseChoicesEmptyForSingleChoice(t *testing.T) {
+	srv := newCompletionServer(t, nil, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	out, err := client.SendMessages(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	if len(out.Choices) != 0 {
+		t.Errorf("Choices = %v, want empty for a single choice", out.Choices)
+	}
+	if out.Content != "hi" {
+		t.Errorf("Content = %q, want hi", out.Content)
+	}
+}
+
 // newCompletionServer returns a test server that captures the request body into
 // capture (when non-nil) and replies with the given chat-completion JSON.
 func newCompletionServer(

--- a/www/docs/advanced/configuration.md
+++ b/www/docs/advanced/configuration.md
@@ -35,8 +35,20 @@ client := llmopenai.NewLLM(
     llmopenai.WithSeed(42),
     llmopenai.WithParallelToolCalls(false),
     llmopenai.WithToolChoice(llm.ToolChoice{Mode: llm.ToolChoiceRequired}),
+    llmopenai.WithLogitBias(map[string]int{"50256": -100}),
+    llmopenai.WithLogprobs(3),
+    llmopenai.WithN(3),
 )
 ```
+
+`WithLogitBias`, `WithLogprobs`, and `WithN` are OpenAI-only sampling knobs
+(inherited by every OpenAI-compatible provider) and are emitted only when set.
+`WithLogitBias` biases or bans tokens by tokenizer id (-100 to 100).
+`WithLogprobs(n)` surfaces per-token log probabilities with up to `n`
+alternatives on `Response.LogProbs`. `WithN(n)` requests `n` completions on
+`Response.Choices`, with the top-level fields mirroring choice 0 (streaming with
+`n > 1` is unsupported). `logit_bias` is rejected by reasoning-tier models (the
+gpt-5 family); use a classic chat model such as `gpt-4o-mini` for it.
 
 `WithToolChoice` controls whether and which tool the model may call. It takes
 the shared `llm.ToolChoice` type — `Mode` is one of `ToolChoiceAuto` (default),

--- a/www/docs/providers/llm.md
+++ b/www/docs/providers/llm.md
@@ -124,7 +124,32 @@ llmopenai.WithFrequencyPenalty(0.5)
 llmopenai.WithPresencePenalty(0.5)
 llmopenai.WithSeed(42)
 llmopenai.WithParallelToolCalls(false)
+llmopenai.WithLogitBias(map[string]int{"1212": 5, "50256": -100})  // bias/ban tokens by id
+llmopenai.WithLogprobs(3)                                          // logprobs:true + top_logprobs:3
+llmopenai.WithN(3)                                                 // n completions per request
 ```
+
+!!! note "Sampling knobs that change the response shape"
+    `WithLogitBias`, `WithLogprobs`, and `WithN` live on the OpenAI client and so
+    also cover every OpenAI-compatible provider (Groq, OpenRouter, xAI, Together,
+    Fireworks, DeepSeek, Mistral, Ollama). They are emitted only when set, and
+    are **OpenAI-only**: Anthropic supports none of them, and Gemini's
+    `candidateCount` (the `n` equivalent) is out of scope — those providers never
+    receive the fields.
+
+    - `WithLogitBias` maps token IDs (tokenizer ids, OpenAI's wire shape) to a
+      bias from -100 (ban) to 100 (force).
+    - `WithLogprobs(n)` requests per-token log probabilities with up to `n`
+      alternatives per position; the result lands on `Response.LogProbs`
+      (`[]llm.TokenLogProb`), nil when not requested.
+    - `WithN(n)` requests `n` completions; all land on `Response.Choices`
+      (`[]llm.Choice`). The top-level `Content` / `FinishReason` / `ToolCalls` /
+      `LogProbs` mirror choice 0, so single-completion callers are unaffected
+      (`Choices` is empty when `n` is unset or `1`). Streaming with `n > 1` is not
+      supported — use the non-streaming `SendMessages` path.
+
+    `logit_bias` is rejected by reasoning-tier models (the gpt-5 family) with an
+    HTTP 400; use a classic chat model such as `gpt-4o-mini` when you need it.
 
 Anthropic:
 


### PR DESCRIPTION
closes #178 

This pull request adds support for several advanced OpenAI-specific sampling options to the LLM interface, including logit biasing, per-token log probabilities, and requesting multiple completions. These features are surfaced through new methods and fields in the API, with comprehensive tests and documentation updates to ensure correct behavior and usability.