### PR TITLE
fix: abandoned stream consumers no longer strand goroutines and tracing spans

### DIFF
--- a/llm/llm.go
+++ b/llm/llm.go
@@ -239,6 +239,9 @@ type LLM interface {
 	) (*Response, error)
 
 	// StreamResponse sends a conversation and returns a channel of streaming events.
+	//
+	// Callers that stop reading before the channel closes MUST cancel ctx;
+	// cancellation is what releases the stream's internal goroutines.
 	StreamResponse(
 		ctx context.Context,
 		messages []message.Message,
@@ -246,6 +249,9 @@ type LLM interface {
 	) <-chan Event
 
 	// StreamResponseWithStructuredOutput streams a response with structured output constraints.
+	//
+	// Callers that stop reading before the channel closes MUST cancel ctx;
+	// cancellation is what releases the stream's internal goroutines.
 	StreamResponseWithStructuredOutput(
 		ctx context.Context,
 		messages []message.Message,
@@ -491,10 +497,30 @@ func (t *tracingLLM) StreamResponse(
 				tracing.SetError(span, evt.Error)
 				t.recordMetrics(ctx, start, nil, evt.Error)
 			}
-			outCh <- evt
+			select {
+			case outCh <- evt:
+			case <-ctx.Done():
+				// The consumer abandoned outCh. Drain innerCh so the
+				// producer's blocking sends unblock and it can close the
+				// channel, then return so the span ends instead of leaking
+				// with this goroutine.
+				drainEvents(innerCh)
+				return
+			}
 		}
 	}()
 	return outCh
+}
+
+// drainEvents consumes the remaining events on ch so the producer's blocking
+// sends unblock and it can reach its close. Used by the tracing forwarders
+// when the consumer abandons the output channel.
+func drainEvents(ch <-chan Event) {
+	for {
+		if _, ok := <-ch; !ok {
+			return
+		}
+	}
 }
 
 func (t *tracingLLM) StreamResponseWithStructuredOutput(
@@ -535,7 +561,16 @@ func (t *tracingLLM) StreamResponseWithStructuredOutput(
 				tracing.SetError(span, evt.Error)
 				t.recordMetrics(ctx, start, nil, evt.Error)
 			}
-			outCh <- evt
+			select {
+			case outCh <- evt:
+			case <-ctx.Done():
+				// The consumer abandoned outCh. Drain innerCh so the
+				// producer's blocking sends unblock and it can close the
+				// channel, then return so the span ends instead of leaking
+				// with this goroutine.
+				drainEvents(innerCh)
+				return
+			}
 		}
 	}()
 	return outCh

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -776,7 +776,9 @@ func (c *Client) runStream(
 	err := openaiStream.Err()
 	if err == nil || errors.Is(err, io.EOF) {
 		if len(acc.Choices) == 0 {
-			eventChan <- llm.Event{Type: types.EventError, Error: errors.New("no response choices in stream")}
+			// Return without emitting: ExecuteStreamWithRetry owns error
+			// emission. Emitting here too would send the consumer the same
+			// error twice.
 			return errors.New("no response choices in stream")
 		}
 		finishReason := c.finishReason(string(acc.Choices[0].FinishReason))

--- a/llm/openai/stream_error_test.go
+++ b/llm/openai/stream_error_test.go
@@ -1,0 +1,46 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/types"
+)
+
+// TestStreamNoChoicesEmitsSingleError locks the error-emission ownership:
+// runStream returns the "no response choices" error WITHOUT emitting it, and
+// ExecuteStreamWithRetry emits it exactly once. The pre-fix double emission
+// (provider emit + retry-layer emit) stranded consumers that stopped reading
+// after the first error event.
+func TestStreamNoChoicesEmitsSingleError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w,
+				"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"choices\":[]}\n\n")
+			_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		}))
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	errCount := 0
+	for evt := range client.StreamResponse(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil) {
+		if evt.Type == types.EventError {
+			errCount++
+		}
+	}
+	if errCount != 1 {
+		t.Fatalf("error events = %d, want exactly 1", errCount)
+	}
+}

--- a/llm/stream_abandon_test.go
+++ b/llm/stream_abandon_test.go
@@ -1,0 +1,137 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/schema"
+	"github.com/joakimcarlsson/ai/tool"
+	"github.com/joakimcarlsson/ai/types"
+)
+
+// stubStreamLLM emulates a vendor client whose stream goroutine emits a
+// scripted event sequence with bare (blocking) sends — the same shape as the
+// real vendor producers — then closes the channel.
+type stubStreamLLM struct {
+	events []Event
+}
+
+func (s *stubStreamLLM) SendMessages(
+	context.Context, []message.Message, []tool.BaseTool,
+) (*Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubStreamLLM) SendMessagesWithStructuredOutput(
+	context.Context, []message.Message, []tool.BaseTool, *schema.StructuredOutputInfo,
+) (*Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubStreamLLM) stream() <-chan Event {
+	ch := make(chan Event)
+	go func() {
+		defer close(ch)
+		for _, evt := range s.events {
+			ch <- evt
+		}
+	}()
+	return ch
+}
+
+func (s *stubStreamLLM) StreamResponse(
+	context.Context, []message.Message, []tool.BaseTool,
+) <-chan Event {
+	return s.stream()
+}
+
+func (s *stubStreamLLM) StreamResponseWithStructuredOutput(
+	context.Context, []message.Message, []tool.BaseTool, *schema.StructuredOutputInfo,
+) <-chan Event {
+	return s.stream()
+}
+
+func (s *stubStreamLLM) Model() model.Model             { return model.Model{} }
+func (s *stubStreamLLM) SupportsStructuredOutput() bool { return true }
+
+// twoErrorEvents is the provider+retry double-emission shape that strands the
+// forwarder when the consumer stops after the first error event.
+func twoErrorEvents() []Event {
+	streamErr := errors.New("stream failed")
+	return []Event{
+		{Type: types.EventError, Error: streamErr},
+		{Type: types.EventError, Error: streamErr},
+	}
+}
+
+// abandonAfterFirstError reads one event, asserts it is an error, then cancels
+// ctx and never reads the channel again — the consumer-abandonment pattern.
+func abandonAfterFirstError(
+	t *testing.T,
+	ch <-chan Event,
+	cancel context.CancelFunc,
+) {
+	t.Helper()
+	evt := <-ch
+	if evt.Type != types.EventError {
+		t.Fatalf("first event type = %v, want %v", evt.Type, types.EventError)
+	}
+	cancel()
+}
+
+// waitForGoroutineBaseline polls until the goroutine count drops back to the
+// pre-stream baseline, failing with a full stack dump if the forwarder (or the
+// stub producer) is still alive after the deadline.
+func waitForGoroutineBaseline(t *testing.T, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	t.Fatalf("goroutines stuck above baseline %d (now %d):\n%s",
+		baseline, runtime.NumGoroutine(), buf[:n])
+}
+
+// TestStreamResponseAbandonedConsumerReleasesForwarder reproduces the strand:
+// the inner stream emits two error events, the consumer reads only the first
+// and cancels ctx. The forwarding goroutine must drain the inner channel and
+// exit (ending its tracing span) — before the fix it blocked forever on the
+// second send to the abandoned channel.
+func TestStreamResponseAbandonedConsumerReleasesForwarder(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inner := &stubStreamLLM{events: twoErrorEvents()}
+	ch := WithTracing(inner, TracingAttrs{}).StreamResponse(ctx, nil, nil)
+
+	abandonAfterFirstError(t, ch, cancel)
+	waitForGoroutineBaseline(t, baseline)
+}
+
+// TestStreamStructuredOutputAbandonedConsumerReleasesForwarder covers the
+// structured-output forwarder variant with the same abandonment pattern.
+func TestStreamStructuredOutputAbandonedConsumerReleasesForwarder(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inner := &stubStreamLLM{events: twoErrorEvents()}
+	ch := WithTracing(inner, TracingAttrs{}).
+		StreamResponseWithStructuredOutput(ctx, nil, nil, nil)
+
+	abandonAfterFirstError(t, ch, cancel)
+	waitForGoroutineBaseline(t, baseline)
+}


### PR DESCRIPTION
## Problem

Two related defects around streaming error delivery:

1. **The `WithTracing` forwarders block forever on abandoned consumers.** `StreamResponse` and `StreamResponseWithStructuredOutput` forward events with a bare `outCh <- evt` on an unbuffered channel. A consumer that stops reading early (e.g. returns on the first `EventError`) strands the forwarding goroutine on its next send — goroutine leak, and the tracing span never ends. The vendor producer behind it stays blocked too.

2. **`llm/openai` emits the "no response choices in stream" error twice.** `runStream` sent the error into the event channel *and* returned it, after which `ExecuteStreamWithRetry` emitted the same error again. A consumer that (reasonably) stops reading after the first error event leaves the second send blocked — which is exactly the abandonment pattern from defect 1.

## Fix

- Both forwarders now `select` on `ctx.Done()`. On cancellation they drain the inner channel (so the vendor producer's blocking sends unblock and it reaches its `close`), then return so the span ends.
- The caller contract is documented on the `LLM` interface: **callers that stop reading before the channel closes MUST cancel ctx** — cancellation is what releases the stream's internal goroutines.
- `runStream` now only returns the no-choices error; `ExecuteStreamWithRetry` is the single emitter, so consumers see it exactly once.

## Audit

Swept all 16 vendor modules under `llm/` for the same emit-and-return pattern: openai was the only one. Every remaining `EventError` send outside `retry.go` is a pre-flight buffered(1)-then-closed channel (bedrock, gemini, and the `errorEvent` helpers in anthropic/openai), which cannot block.

## Tests

- `llm/stream_abandon_test.go` reproduces the strand (inner stream emits two errors, consumer reads one and cancels) and asserts both goroutines exit via `runtime.NumGoroutine` polling — deliberately no goleak dependency, which would enter every consumer's module graph through `llm/go.mod`. Both tests fail on the pre-fix code.
- `llm/openai/stream_error_test.go` runs an httptest SSE server returning an empty-choices stream and asserts exactly one `EventError` reaches the consumer.

`go vet`, `golangci-lint` and the full test suites are green in both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)