### PR TITLE
chore: land the whole LLM provider fleet on llm@v0.4.0

### DIFF
--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.46.0
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.3.0
 	github.com/joakimcarlsson/ai/schema v0.1.0

--- a/llm/azure/go.mod
+++ b/llm/azure/go.mod
@@ -4,8 +4,9 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/llm/openai v0.2.0
+	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 	github.com/openai/openai-go/v3 v3.37.0
 )
@@ -22,7 +23,6 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect

--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/llm/bedrock
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/llm/anthropic v0.2.2
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.3.0

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/cerebras
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 )
 
 require (

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 )

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/fireworks
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 )
 
 require (

--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/message v0.2.0
 	github.com/joakimcarlsson/ai/model v0.2.0
 	github.com/joakimcarlsson/ai/schema v0.1.0

--- a/llm/groq/go.mod
+++ b/llm/groq/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/llm/groq
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/llm/openai v0.2.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.1.0

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 )
 
 require (

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/ollama
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 )
 
 require (

--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/llm/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.3.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 	github.com/joakimcarlsson/ai/schema v0.1.0

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/openrouter
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.3.0
 )

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/perplexity
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.1.0
 )

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/together
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
-	github.com/joakimcarlsson/ai/llm/openai v0.3.2
+	github.com/joakimcarlsson/ai/llm v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 )
 
 require (

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -3,8 +3,9 @@ module github.com/joakimcarlsson/ai/llm/vertexai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/llm/gemini v0.2.3
+	github.com/joakimcarlsson/ai/message v0.2.0
 	github.com/joakimcarlsson/ai/model v0.2.0
 	google.golang.org/genai v1.58.0
 )
@@ -25,7 +26,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect

--- a/llm/xai/go.mod
+++ b/llm/xai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/llm/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.1.0
+	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/llm/openai v0.2.0
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/model v0.1.0


### PR DESCRIPTION
`llm@v0.4.0` adds `SelectResponseHeaders`, the `Choice`/`TokenLogProb` types, the `Response.{LogProbs,Choices,RequestID,ResponseHeaders}` fields (#189, #191), and a streaming goroutine-leak fix in the `tracingLLM` wrapper (#192).

The `tracingLLM` wrapper (which holds the #192 fix) is instantiated inside the provider constructors, so a provider only delivers the fix once it requires `llm@v0.4.0`. This PR lands **every** LLM provider module on `llm@v0.4.0`:

**Direct providers** (also gained `WithHTTPClient` via #190):
- `llm/anthropic`, `llm/openai` (reference the new symbols directly)
- `llm/azure`, `llm/bedrock`, `llm/gemini`, `llm/groq`, `llm/vertexai`, `llm/xai`

**OpenAI-compatible wrappers** (bumped `require llm/openai@v0.4.0`; `llm@v0.4.0` pulled transitively):
- `llm/cerebras`, `llm/deepseek`, `llm/fireworks`, `llm/mistral`, `llm/ollama`, `llm/openrouter`, `llm/perplexity`, `llm/together`

No code changes; all 16 modules build clean with `GOWORK=off go build ./...`.

Follow-up after merge — tag (direct providers minor for the new option; wrappers patch for the dep bump):
`llm/openai v0.4.0`, `llm/anthropic v0.3.0`, `llm/azure v0.5.0`, `llm/bedrock v0.2.0`, `llm/gemini v0.3.0`, `llm/groq v0.4.0`, `llm/vertexai v0.2.0`, `llm/xai v0.4.0`, `llm/cerebras v0.2.3`, `llm/deepseek v0.2.3`, `llm/fireworks v0.2.3`, `llm/mistral v0.2.3`, `llm/ollama v0.2.3`, `llm/openrouter v0.2.4`, `llm/perplexity v0.2.3`, `llm/together v0.2.3`.