### PR TITLE
fix(agent): remove redundant system message persistence in buildMessages

### DIFF
--- a/agent/messages.go
+++ b/agent/messages.go
@@ -128,15 +128,6 @@ func (a *Agent) buildMessages(
 		sysMsg := message.NewSystemMessage(systemPrompt)
 		sysMsg.Model = a.llm.Model().ID
 		messages = append(messages, sysMsg)
-
-		if a.session != nil && len(sessionMessages) == 0 {
-			if err := a.session.AddMessages(
-				ctx,
-				[]message.Message{sysMsg},
-			); err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	messages = append(messages, sessionMessages...)

--- a/tests/agent/session_sysprompt_test.go
+++ b/tests/agent/session_sysprompt_test.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
+)
+
+func TestSessionBugs_SystemPromptDuplication(t *testing.T) {
+	mock := newMockLLM(
+		mockResponse{
+			Content:      "Response 1",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+		mockResponse{
+			Content:      "Response 2",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+	)
+
+	store := session.MemoryStore()
+	ctx := context.Background()
+
+	a := agent.New(mock,
+		agent.WithSystemPrompt("You are a test assistant."),
+		agent.WithSession("test-sys-dup", store),
+	)
+
+	// Turn 1
+	_, err := a.Chat(ctx, "Hello")
+	if err != nil {
+		t.Fatalf("turn 1 failed: %v", err)
+	}
+
+	// Turn 2
+	_, err = a.Chat(ctx, "How are you?")
+	if err != nil {
+		t.Fatalf("turn 2 failed: %v", err)
+	}
+
+	// Check calls
+	if len(mock.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(mock.calls))
+	}
+
+	// First call should have 1 system message
+	countSys := 0
+	for _, msg := range mock.calls[0] {
+		if msg.Role == message.System {
+			countSys++
+		}
+	}
+	if countSys != 1 {
+		t.Errorf("call 1: expected 1 system message, got %d", countSys)
+	}
+
+	// Second call currently has 2 system messages (Bug 1)
+	countSys = 0
+	for _, msg := range mock.calls[1] {
+		if msg.Role == message.System {
+			countSys++
+		}
+	}
+	if countSys != 1 {
+		t.Errorf("call 2: expected 1 system message, got %d (Bug 1)", countSys)
+	}
+}
+
+func TestSessionBugs_StaleSystemPrompt(t *testing.T) {
+	mock := newMockLLM(
+		mockResponse{
+			Content:      "Response 1",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+		mockResponse{
+			Content:      "Response 2",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+	)
+
+	store := session.MemoryStore()
+	ctx := context.Background()
+
+	// Initial agent with System Prompt A
+	a1 := agent.New(mock,
+		agent.WithSystemPrompt("Prompt A"),
+		agent.WithSession("test-stale-sys", store),
+	)
+
+	_, err := a1.Chat(ctx, "Hello")
+	if err != nil {
+		t.Fatalf("chat 1 failed: %v", err)
+	}
+
+	// New agent with same session but System Prompt B
+	a2 := agent.New(mock,
+		agent.WithSystemPrompt("Prompt B"),
+		agent.WithSession("test-stale-sys", store),
+	)
+
+	_, err = a2.Chat(ctx, "Hello again")
+	if err != nil {
+		t.Fatalf("chat 2 failed: %v", err)
+	}
+
+	// Check calls
+	if len(mock.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(mock.calls))
+	}
+
+	// Second call should NOT have Prompt A in its history
+	for _, msg := range mock.calls[1] {
+		if msg.Role == message.System && msg.Content().Text == "Prompt A" {
+			t.Errorf("call 2 contains stale Prompt A (Bug 2)")
+		}
+	}
+}


### PR DESCRIPTION
resolves two critical flaws in how the Agent handles system instructions when a session is active.

  1. System Prompt Duplication
  The Bug:
  Whenever a session was initialized or loaded, the buildMessages logic would detect that the session was empty (or just starting) and persist the current system prompt into the session storage. However, the buildMessages function also explicitly
  prepends the current system prompt to every outgoing message list.

  The Impact:
  The LLM would receive the system instructions twice:
   1. Once from the explicit prepend in the message builder.
   2. A second time as the first message retrieved from the session history.

  This wasted tokens and, in some cases, caused models to over-weight the system instructions or become confused by the redundancy.

  2. Stale System Prompts
  The Bug:
  Because the system prompt was being saved to the session history, it became a permanent part of that conversation's "audit log." If a developer updated the Agent's system prompt (e.g., changing its persona or constraints) in the middle of a session,
  the old prompt remained stored in the session history.

  The Impact:
  The LLM would receive conflicting instructions:
   1. The new prompt (prepended by the builder).
   2. The old prompt (loaded from the session history).

  This made it impossible to dynamically update agent behavior within an existing session, as the model would effectively be "haunted" by its previous instructions.

  ---

  The Resolution
  The fix removes the persistence of system messages entirely from the session store logic in agent/messages.go. 

  By treating the system prompt as dynamic application state rather than persistent conversation history, we ensure that:
   * The LLM only ever sees the system prompt once.
   * The LLM always sees the most current version of the instructions provided to the agent.
   * The session store remains a pure log of the exchange (User, Assistant, Tool, and Summary messages) without polluting it with architectural instructions.


Tests that reproduced the bugs in tests/agent/session_sysprompt_test.go.