### PR TITLE
feat: implement session summarization compaction (Option A+E)

### DIFF
--- a/agent/messages.go
+++ b/agent/messages.go
@@ -182,13 +182,23 @@ func (a *Agent) buildMessages(
 
 		messages = result.Messages
 
-		if result.SessionUpdate != nil && a.session != nil &&
-			len(result.SessionUpdate.AddMessages) > 0 {
-			if err := a.session.AddMessages(
-				ctx,
-				result.SessionUpdate.AddMessages,
-			); err != nil {
-				return nil, fmt.Errorf("failed to save session update: %w", err)
+		if result.SessionUpdate != nil && a.session != nil {
+			if len(result.SessionUpdate.AddMessages) > 0 {
+				if err := a.session.AddMessages(
+					ctx,
+					result.SessionUpdate.AddMessages,
+				); err != nil {
+					return nil, fmt.Errorf("failed to save session update: %w", err)
+				}
+			}
+			if result.SessionUpdate.Compact != nil {
+				if err := a.session.Compact(
+					ctx,
+					result.SessionUpdate.Compact.Summary,
+					result.SessionUpdate.Compact.Keep,
+				); err != nil {
+					return nil, fmt.Errorf("failed to compact session: %w", err)
+				}
 			}
 		}
 	}
@@ -250,13 +260,23 @@ func (a *Agent) buildContinueMessages(
 
 		messages = result.Messages
 
-		if result.SessionUpdate != nil && a.session != nil &&
-			len(result.SessionUpdate.AddMessages) > 0 {
-			if err := a.session.AddMessages(
-				ctx,
-				result.SessionUpdate.AddMessages,
-			); err != nil {
-				return nil, fmt.Errorf("failed to save session update: %w", err)
+		if result.SessionUpdate != nil && a.session != nil {
+			if len(result.SessionUpdate.AddMessages) > 0 {
+				if err := a.session.AddMessages(
+					ctx,
+					result.SessionUpdate.AddMessages,
+				); err != nil {
+					return nil, fmt.Errorf("failed to save session update: %w", err)
+				}
+			}
+			if result.SessionUpdate.Compact != nil {
+				if err := a.session.Compact(
+					ctx,
+					result.SessionUpdate.Compact.Summary,
+					result.SessionUpdate.Compact.Keep,
+				); err != nil {
+					return nil, fmt.Errorf("failed to compact session: %w", err)
+				}
 			}
 		}
 	}

--- a/memory/postgres/session.go
+++ b/memory/postgres/session.go
@@ -110,10 +110,21 @@ func (s *pgSession) GetMessages(
 	ctx context.Context,
 	limit *int,
 ) ([]message.Message, error) {
+	// Find the created_at of the most recent summary
+	var lastSummaryAt int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(created_at), 0)
+		FROM messages
+		WHERE session_id = $1 AND role = $2
+	`, s.id, string(message.Summary)).Scan(&lastSummaryAt)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+
 	query := `
 		SELECT parts
 		FROM messages
-		WHERE session_id = $1
+		WHERE session_id = $1 AND created_at >= $2
 		ORDER BY created_at ASC
 	`
 	if limit != nil {
@@ -121,14 +132,14 @@ func (s *pgSession) GetMessages(
 			SELECT parts FROM (
 				SELECT parts, created_at
 				FROM messages
-				WHERE session_id = $1
+				WHERE session_id = $1 AND created_at >= $2
 				ORDER BY created_at DESC
 				LIMIT %d
 			) sub ORDER BY created_at ASC
 		`, *limit)
 	}
 
-	rows, err := s.db.QueryContext(ctx, query, s.id)
+	rows, err := s.db.QueryContext(ctx, query, s.id, lastSummaryAt)
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +187,21 @@ func (s *pgSession) AddMessages(
 		}
 	}
 	return nil
+}
+
+func (s *pgSession) Compact(
+	ctx context.Context,
+	summary message.Message,
+	keep []message.Message,
+) error {
+	// For database stores, we append the summary and the messages to keep
+	// with fresh timestamps to ensure they are at the end of the history.
+	// We use the Summary role to indicate a baseline.
+	summary.Role = message.Summary
+	if err := s.AddMessages(ctx, []message.Message{summary}); err != nil {
+		return err
+	}
+	return s.AddMessages(ctx, keep)
 }
 
 func (s *pgSession) PopMessage(ctx context.Context) (*message.Message, error) {

--- a/memory/sqlite/session.go
+++ b/memory/sqlite/session.go
@@ -122,6 +122,17 @@ func (s *sqliteSession) GetMessages(
 ) ([]message.Message, error) {
 	table := s.prefix + "messages"
 
+	// Find the ID of the most recent summary
+	var lastSummaryID int64
+	err := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT COALESCE(MAX(id), 0)
+		FROM %s
+		WHERE session_id = ? AND role = ?
+	`, table), s.id, string(message.Summary)).Scan(&lastSummaryID)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+
 	var query string
 	var args []any
 
@@ -129,15 +140,15 @@ func (s *sqliteSession) GetMessages(
 		query = fmt.Sprintf(`
 			SELECT parts FROM (
 				SELECT parts, id FROM %s
-				WHERE session_id = ? ORDER BY id DESC LIMIT ?
+				WHERE session_id = ? AND id >= ? ORDER BY id DESC LIMIT ?
 			) sub ORDER BY id ASC`, table)
-		args = []any{s.id, *limit}
+		args = []any{s.id, lastSummaryID, *limit}
 	} else {
 		query = fmt.Sprintf(
-			"SELECT parts FROM %s WHERE session_id = ? ORDER BY id ASC",
+			"SELECT parts FROM %s WHERE session_id = ? AND id >= ? ORDER BY id ASC",
 			table,
 		)
-		args = []any{s.id}
+		args = []any{s.id, lastSummaryID}
 	}
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -191,6 +202,21 @@ func (s *sqliteSession) AddMessages(
 		}
 	}
 	return nil
+}
+
+func (s *sqliteSession) Compact(
+	ctx context.Context,
+	summary message.Message,
+	keep []message.Message,
+) error {
+	// For database stores, we append the summary and the messages to keep
+	// with fresh timestamps to ensure they are at the end of the history.
+	// We use the Summary role to indicate a baseline.
+	summary.Role = message.Summary
+	if err := s.AddMessages(ctx, []message.Message{summary}); err != nil {
+		return err
+	}
+	return s.AddMessages(ctx, keep)
 }
 
 func (s *sqliteSession) PopMessage(

--- a/session/file.go
+++ b/session/file.go
@@ -104,6 +104,18 @@ func (s *fileSession) AddMessages(
 	return s.saveMessages(existing)
 }
 
+func (s *fileSession) Compact(
+	_ context.Context,
+	summary message.Message,
+	keep []message.Message,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	messages := append([]message.Message{summary}, keep...)
+	return s.saveMessages(messages)
+}
+
 func (s *fileSession) SetMessages(
 	_ context.Context,
 	msgs []message.Message,

--- a/session/in_memory.go
+++ b/session/in_memory.go
@@ -88,6 +88,18 @@ func (s *memorySession) AddMessages(
 	return nil
 }
 
+func (s *memorySession) Compact(
+	_ context.Context,
+	summary message.Message,
+	keep []message.Message,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.messages = append([]message.Message{summary}, keep...)
+	return nil
+}
+
 func (s *memorySession) SetMessages(
 	_ context.Context,
 	msgs []message.Message,

--- a/session/store.go
+++ b/session/store.go
@@ -12,6 +12,7 @@ type Session interface {
 	GetMessages(ctx context.Context, limit *int) ([]message.Message, error)
 	AddMessages(ctx context.Context, msgs []message.Message) error
 	PopMessage(ctx context.Context) (*message.Message, error)
+	Compact(ctx context.Context, summary message.Message, keep []message.Message) error
 	Clear(ctx context.Context) error
 }
 

--- a/tests/agent/session_compaction_test.go
+++ b/tests/agent/session_compaction_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
+)
+
+func TestSessionBugs_ReSummarization(t *testing.T) {
+	ctx := context.Background()
+	store := session.MemoryStore()
+	sess, err := store.Create(ctx, "compaction-test")
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	msgs := []message.Message{
+		message.NewUserMessage("Hello"),
+		message.NewAssistantMessage(),
+		message.NewUserMessage("Tell me a story"),
+		message.NewAssistantMessage(),
+	}
+	msgs[1].AppendContent("Hi there!")
+	msgs[3].AppendContent("Once upon a time...")
+
+	if err := sess.AddMessages(ctx, msgs); err != nil {
+		t.Fatalf("failed to add messages: %v", err)
+	}
+
+	summary := message.NewSummaryMessage("This is a summary of the conversation so far.")
+
+	// Keep the last 2 messages
+	keep := msgs[2:]
+
+	// Use type assertion to call Compact if it's not in the interface yet
+	type compacter interface {
+		Compact(ctx context.Context, summary message.Message, keep []message.Message) error
+	}
+
+	if c, ok := sess.(compacter); ok {
+		if err := c.Compact(ctx, summary, keep); err != nil {
+			t.Fatalf("failed to compact session: %v", err)
+		}
+	} else {
+		t.Skip("Compact not implemented on session")
+	}
+
+	newMsgs, err := sess.GetMessages(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to get messages: %v", err)
+	}
+
+	if len(newMsgs) != 3 {
+		t.Errorf("expected 3 messages after compaction, got %d", len(newMsgs))
+	}
+
+	if newMsgs[0].Content().Text != summary.Content().Text {
+		t.Errorf("expected first message to be summary, got %s", newMsgs[0].Content().Text)
+	}
+
+	if newMsgs[1].Content().Text != msgs[2].Content().Text {
+		t.Errorf("expected second message to be %s, got %s", msgs[2].Content().Text, newMsgs[1].Content().Text)
+	}
+
+	if newMsgs[2].Content().Text != msgs[3].Content().Text {
+		t.Errorf("expected third message to be %s, got %s", msgs[3].Content().Text, newMsgs[2].Content().Text)
+	}
+}
+
+func TestSessionBugs_KeepRecentLost(t *testing.T) {
+	ctx := context.Background()
+	store := session.MemoryStore()
+	sess, err := store.Create(ctx, "compaction-test-2")
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	// Create a complex sequence with tool calls that MUST be kept together
+	msgs := []message.Message{
+		message.NewUserMessage("Old message"),
+		message.NewAssistantMessage(),
+		message.NewUserMessage("Current task"),
+		message.NewAssistantMessage(),
+		message.NewMessage(message.Tool, []message.ContentPart{
+			message.ToolResult{ToolCallID: "call-1", Name: "tool", Content: "Result"},
+		}),
+		message.NewAssistantMessage(),
+	}
+	msgs[1].AppendContent("Old response")
+	msgs[3].AppendContent("I will help with that")
+	msgs[3].AppendToolCalls([]message.ToolCall{
+		{ID: "call-1", Name: "tool", Input: "{}"},
+	})
+	msgs[5].AppendContent("I finished the task")
+
+	if err := sess.AddMessages(ctx, msgs); err != nil {
+		t.Fatalf("failed to add messages: %v", err)
+	}
+
+	summary := message.NewSummaryMessage("Summary")
+
+	// Keep last 4 messages (the tool call sequence)
+	keep := msgs[2:]
+
+	type compacter interface {
+		Compact(ctx context.Context, summary message.Message, keep []message.Message) error
+	}
+
+	if c, ok := sess.(compacter); ok {
+		if err := c.Compact(ctx, summary, keep); err != nil {
+			t.Fatalf("failed to compact session: %v", err)
+		}
+	} else {
+		t.Skip("Compact not implemented on session")
+	}
+
+	newMsgs, err := sess.GetMessages(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to get messages: %v", err)
+	}
+
+	if len(newMsgs) != 5 { // summary + 4 kept
+		t.Errorf("expected 5 messages after compaction, got %d", len(newMsgs))
+	}
+}

--- a/tests/session/compact_test.go
+++ b/tests/session/compact_test.go
@@ -1,0 +1,52 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
+)
+
+func TestMemorySession_Compact(t *testing.T) {
+	ctx := context.Background()
+	store := session.MemoryStore()
+	s, _ := store.Create(ctx, "s1")
+
+	// Add some initial messages
+	msgs := []message.Message{
+		message.NewUserMessage("msg 1"),
+		message.NewMessage(message.Assistant, []message.ContentPart{message.TextContent{Text: "reply 1"}}),
+		message.NewUserMessage("msg 2"),
+		message.NewMessage(message.Assistant, []message.ContentPart{message.TextContent{Text: "reply 2"}}),
+	}
+	if err := s.AddMessages(ctx, msgs); err != nil {
+		t.Fatalf("add error: %v", err)
+	}
+
+	summary := message.NewSummaryMessage("This is a summary of the first two messages")
+	keep := msgs[2:] // Keep "msg 2" and "reply 2"
+
+	if err := s.Compact(ctx, summary, keep); err != nil {
+		t.Fatalf("compact error: %v", err)
+	}
+
+	got, err := s.GetMessages(ctx, nil)
+	if err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 messages (summary + 2 kept), got %d", len(got))
+	}
+
+	if got[0].Role != message.Summary {
+		t.Errorf("expected first message to be summary, got %s", got[0].Role)
+	}
+	if got[1].Content().Text != "msg 2" {
+		t.Errorf("expected second message to be 'msg 2', got %q", got[1].Content().Text)
+	}
+	if got[2].Content().Text != "reply 2" {
+		t.Errorf("expected third message to be 'reply 2', got %q", got[2].Content().Text)
+	}
+}

--- a/tokens/strategy.go
+++ b/tokens/strategy.go
@@ -27,6 +27,17 @@ type SessionUpdate struct {
 	// AddMessages appends messages to the session.
 	// The full conversation history is preserved for auditing.
 	AddMessages []message.Message
+	// Compact replaces the session history with a summary and a set of messages to keep.
+	// Used by summarization strategies to prevent history bloat.
+	Compact *CompactUpdate
+}
+
+// CompactUpdate contains the data needed to compact a session.
+type CompactUpdate struct {
+	// Summary is the new summary of the conversation.
+	Summary message.Message
+	// Keep is the list of recent messages to retain alongside the summary.
+	Keep []message.Message
 }
 
 // StrategyInput contains all data needed for context management.

--- a/tokens/summarize/strategy.go
+++ b/tokens/summarize/strategy.go
@@ -98,7 +98,10 @@ func (s *summarizeStrategy) Fit(
 	return &tokens.StrategyResult{
 		Messages: llmMessages,
 		SessionUpdate: &tokens.SessionUpdate{
-			AddMessages: []message.Message{summaryMsgForSession},
+			Compact: &tokens.CompactUpdate{
+				Summary: summaryMsgForSession,
+				Keep:    toKeep,
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
1. The Re-Summarization Loop
  The Bug:
  Previously, when the conversation became too long, the summarization strategy would generate a summary and simply append it to the session history using AddMessages. 

  The Impact:
  Because the old, bloated messages were never removed or hidden, the session history continued to grow. On the very next turn, the history would still be "too long," triggering the summarizer again. This summarizer would then summarize the previous
  summary plus the new messages, creating a "nested summary" effect. Eventually, the context window would be filled entirely with redundant summaries of summaries, leaving no room for actual conversation.

  2. Loss of "Keep Recent" Context
  The Bug:
  The summarization strategy is designed to keep a specific number of recent messages (e.g., the last 10 messages) in their original, full-text form to maintain immediate context (like active tool-call sequences). However, because the storage layer
  only supported AddMessages, there was no clean way for the storage backend to distinguish between "new messages to append" and "the specific baseline history we want to keep."

  The Impact:
  In many cases, the "recent" messages that were supposed to be preserved were either duplicated or, if the session was manually cleared and reset to fit the summary, important metadata (like tool call IDs) could be lost. This was particularly breaking
  for multi-turn tool interactions where the model needs to see the original tool_call and tool_result to continue correctly.

  ---

  The Resolution: "Compaction" 
  The fix introduces a new Compact method to the session interface, which handles history reduction differently depending on the storage backend:

   * For File and Memory Stores: These now physically replace the entire history with a single Summary message followed by the Keep messages. This keeps the files small and prevents the loop.
   * For Database Stores (Postgres/SQLite): These follow an "Audit-Safe" approach. They append the new summary to the database (preserving the full history for developers/compliance), but the GetMessages logic was updated to use the latest summary as a
     baseline. When the agent asks for history, the DB only returns messages starting from that latest summary.

  Key Benefits:
   1. Fixed Context: Summarization now happens exactly once at the boundary, resetting the token count effectively.
   2. Integrity: Recent tool calls and full-text messages are guaranteed to stay in the context window.
   3. Efficiency: Disk and memory usage are significantly reduced for file-based sessions, while audit logs are preserved for database-backed sessions.

This PR introduces a 'Compact' method to the Session interface and implements it across all storage backends (file, memory, postgres, sqlite).

- File/Memory stores: Compact replaces the history with [summary, ...keep].
- DB stores (Postgres/SQLite): Compact appends the summary and kept messages. GetMessages is updated to filter results starting from the most recent summary.
- Summarize strategy is updated to return CompactUpdate instead of AddMessages.
- Agent is updated to handle CompactUpdate during message building.

This resolves the re-summarization loop bug and prevents loss of 'keepRecent' messages.