### PR TITLE
fix(sqlite): ensure session deletion also removes associated messages

### DIFF
--- a/memory/postgres/tests/session_test.go
+++ b/memory/postgres/tests/session_test.go
@@ -1,9 +1,11 @@
 package postgres_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -203,7 +205,6 @@ func TestPostgresSession_GetMessagesWithLimit(t *testing.T) {
 			message.NewUserMessage(fmt.Sprintf("msg %d", i)),
 		})
 		require.NoError(t, err)
-		// Small sleep to ensure created_at ordering if the DB resolution is low
 		time.Sleep(2 * time.Millisecond)
 	}
 
@@ -400,7 +401,6 @@ func TestPostgresSession_PersistsAcrossLoads(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// A fresh store against the same database must see the message.
 	store2 := newStore(t)
 	loaded, err := store2.Load(ctx, id)
 	require.NoError(t, err)
@@ -428,7 +428,6 @@ func TestPostgresStore_DeleteRemovesSessionMessages(t *testing.T) {
 	err = store.Delete(ctx, id)
 	require.NoError(t, err)
 
-	// Recreate the same session ID and verify no old messages remain.
 	s, err = store.Create(ctx, id)
 	require.NoError(t, err)
 
@@ -642,4 +641,217 @@ func TestPostgresSession_ConcurrentAddMessages(t *testing.T) {
 	got, err := s.GetMessages(ctx, nil)
 	require.NoError(t, err)
 	assert.Len(t, got, writers*perWriter)
+}
+
+func TestPostgresSession_GetMessagesNegativeLimit(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+	}))
+
+	limit := -1
+	_, err = s.GetMessages(ctx, &limit)
+	require.Error(t, err, "Postgres rejects a negative LIMIT")
+}
+
+func TestPostgresSession_CreatedAtRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	msg := message.NewUserMessage("hello")
+	msg.CreatedAt = 1_700_000_000_000_000_000
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(1_700_000_000_000_000_000), got[0].CreatedAt)
+}
+
+func TestPostgresSession_LargeContentRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	large := strings.Repeat("lorem ipsum ", 100_000)
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage(large),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, large, got[0].Content().Text)
+}
+
+func TestPostgresSession_MultipleToolCallsInOneMessage(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	msg := message.NewMessage(message.Assistant, []message.ContentPart{
+		message.TextContent{Text: "running tools"},
+		message.ToolCall{ID: "tc_1", Name: "search", Input: `{"q":"a"}`},
+		message.ToolCall{ID: "tc_2", Name: "lookup", Input: `{"id":2}`},
+	})
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	calls := got[0].ToolCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, "search", calls[0].Name)
+	assert.Equal(t, "tc_2", calls[1].ID)
+	assert.Equal(t, "running tools", got[0].Content().Text)
+}
+
+func TestPostgresSession_ImageURLRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	msg := message.NewMessage(message.User, []message.ContentPart{
+		message.TextContent{Text: "look"},
+		message.ImageURLContent{URL: "https://example.com/cat.png", Detail: "high"},
+	})
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	images := got[0].ImageURLContent()
+	require.Len(t, images, 1)
+	assert.Equal(t, "https://example.com/cat.png", images[0].URL)
+	assert.Equal(t, "high", images[0].Detail)
+}
+
+func TestPostgresSession_BinaryContentRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	data := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	msg := message.NewMessage(message.User, []message.ContentPart{
+		message.BinaryContent{MIMEType: "application/octet-stream", Data: data},
+	})
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	bin := got[0].BinaryContent()
+	require.Len(t, bin, 1)
+	assert.Equal(t, "application/octet-stream", bin[0].MIMEType)
+	assert.True(t, bytes.Equal(data, bin[0].Data))
+}
+
+func TestPostgresSession_SummaryRoleRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewSummaryMessage("conversation summary"),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, message.Summary, got[0].Role)
+	assert.Equal(t, "conversation summary", got[0].Content().Text)
+}
+
+func TestPostgresSession_EmptySessionID(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, "", s.ID())
+
+	exists, err := store.Exists(ctx, "")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("empty id"),
+	}))
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	require.NoError(t, store.Delete(ctx, ""))
+}
+
+func TestPostgresStore_ManySessions(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	const n = 50
+	prefix := sessionID(t)
+	for i := range n {
+		id := fmt.Sprintf("%s-%d", prefix, i)
+		s, err := store.Create(ctx, id)
+		require.NoError(t, err)
+		require.NoError(t, s.AddMessages(ctx, []message.Message{
+			message.NewUserMessage(fmt.Sprintf("hello %d", i)),
+		}))
+	}
+
+	for i := range n {
+		id := fmt.Sprintf("%s-%d", prefix, i)
+		exists, err := store.Exists(ctx, id)
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		s, err := store.Load(ctx, id)
+		require.NoError(t, err)
+		got, err := s.GetMessages(ctx, nil)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, fmt.Sprintf("hello %d", i), got[0].Content().Text)
+	}
+}
+
+func TestPostgresSession_ContextCancellation(t *testing.T) {
+	store := newStore(t)
+
+	s, err := store.Create(context.Background(), sessionID(t))
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = s.AddMessages(canceled, []message.Message{
+		message.NewUserMessage("nope"),
+	})
+	require.Error(t, err)
+
+	_, err = s.GetMessages(canceled, nil)
+	require.Error(t, err)
+
+	_, err = s.PopMessage(canceled)
+	require.Error(t, err)
 }

--- a/memory/postgres/tests/session_test.go
+++ b/memory/postgres/tests/session_test.go
@@ -3,11 +3,14 @@ package postgres_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/joakimcarlsson/ai/memory/postgres"
 	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -15,7 +18,14 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func setupPostgres(ctx context.Context, t *testing.T) string {
+// sharedConnStr is the connection string for a single Postgres container shared
+// by every test in the package. Spinning up one container instead of one per
+// test keeps the suite fast; tests isolate themselves with unique session IDs.
+var sharedConnStr string
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
 	pgContainer, err := pgmodule.Run(ctx,
 		"postgres:15-alpine",
 		pgmodule.WithDatabase("testdb"),
@@ -24,85 +34,117 @@ func setupPostgres(ctx context.Context, t *testing.T) string {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second)),
+				WithStartupTimeout(60*time.Second)),
 	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start postgres container: %v\n", err)
+		os.Exit(1)
+	}
+
+	sharedConnStr, err = pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get connection string: %v\n", err)
+		_ = pgContainer.Terminate(ctx)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := pgContainer.Terminate(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to terminate container: %v\n", err)
+	}
+
+	os.Exit(code)
+}
+
+// newStore returns a session store backed by the shared container.
+func newStore(t *testing.T, opts ...postgres.Option) session.Store {
+	t.Helper()
+	store, err := postgres.SessionStore(context.Background(), sharedConnStr, opts...)
 	require.NoError(t, err)
+	return store
+}
 
-	t.Cleanup(func() {
-		if err := pgContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	return connStr
+// sessionID returns a session id unique to the calling test so tests sharing
+// the same tables do not interfere with one another.
+func sessionID(t *testing.T) string {
+	t.Helper()
+	return "sess-" + t.Name()
 }
 
 func TestPostgresStore_CreateAndLoad(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
+	id := sessionID(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
-	require.NoError(t, err)
-
-	exists, err := store.Exists(ctx, "s1")
+	exists, err := store.Exists(ctx, id)
 	require.NoError(t, err)
 	assert.False(t, exists)
 
-	s, err := store.Create(ctx, "s1")
+	s, err := store.Create(ctx, id)
 	require.NoError(t, err)
-	assert.Equal(t, "s1", s.ID())
+	assert.Equal(t, id, s.ID())
 
-	exists, err = store.Exists(ctx, "s1")
+	exists, err = store.Exists(ctx, id)
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	loaded, err := store.Load(ctx, "s1")
+	loaded, err := store.Load(ctx, id)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
-	assert.Equal(t, "s1", loaded.ID())
+	assert.Equal(t, id, loaded.ID())
 }
 
 func TestPostgresStore_ExistsMissing(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
-	require.NoError(t, err)
-
-	exists, err := store.Exists(ctx, "missing")
+	exists, err := store.Exists(ctx, sessionID(t))
 	require.NoError(t, err)
 	assert.False(t, exists)
+}
+
+func TestPostgresStore_CreateDuplicateFails(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+	id := sessionID(t)
+
+	_, err := store.Create(ctx, id)
+	require.NoError(t, err)
+
+	_, err = store.Create(ctx, id)
+	require.Error(t, err, "creating a session with a duplicate id should fail")
 }
 
 func TestPostgresStore_Delete(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
+	id := sessionID(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
+	_, err := store.Create(ctx, id)
 	require.NoError(t, err)
 
-	_, err = store.Create(ctx, "s1")
+	err = store.Delete(ctx, id)
 	require.NoError(t, err)
 
-	err = store.Delete(ctx, "s1")
-	require.NoError(t, err)
-
-	exists, err := store.Exists(ctx, "s1")
+	exists, err := store.Exists(ctx, id)
 	require.NoError(t, err)
 	assert.False(t, exists)
 }
 
+func TestPostgresStore_DeleteMissingIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	err := store.Delete(ctx, sessionID(t))
+	require.NoError(t, err)
+}
+
 func TestPostgresSession_AddAndGetMessages(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
-	require.NoError(t, err)
-
-	s, err := store.Create(ctx, "s1")
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
 	msgs := []message.Message{
@@ -121,17 +163,42 @@ func TestPostgresSession_AddAndGetMessages(t *testing.T) {
 	assert.Equal(t, message.System, got[1].Role)
 }
 
+func TestPostgresSession_GetMessagesEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, got, "expected an empty, non-nil slice")
+	assert.Empty(t, got)
+}
+
+func TestPostgresSession_AddMessagesEmptyBatch(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, nil))
+	require.NoError(t, s.AddMessages(ctx, []message.Message{}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
 func TestPostgresSession_GetMessagesWithLimit(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
-	s, err := store.Create(ctx, "s1")
-	require.NoError(t, err)
-
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err = s.AddMessages(ctx, []message.Message{
 			message.NewUserMessage(fmt.Sprintf("msg %d", i)),
 		})
@@ -148,14 +215,29 @@ func TestPostgresSession_GetMessagesWithLimit(t *testing.T) {
 	assert.Equal(t, "msg 4", got[1].Content().Text)
 }
 
-func TestPostgresSession_PopMessage(t *testing.T) {
+func TestPostgresSession_GetMessagesLimitExceedsCount(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
-	s, err := store.Create(ctx, "s1")
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+		message.NewUserMessage("b"),
+	}))
+
+	limit := 10
+	got, err := s.GetMessages(ctx, &limit)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
+func TestPostgresSession_PopMessage(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
 	err = s.AddMessages(ctx, []message.Message{
@@ -177,13 +259,36 @@ func TestPostgresSession_PopMessage(t *testing.T) {
 
 func TestPostgresSession_PopMessageEmpty(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
-	s, err := store.Create(ctx, "s1")
+	popped, err := s.PopMessage(ctx)
 	require.NoError(t, err)
+	assert.Nil(t, popped)
+}
+
+func TestPostgresSession_PopMessageDrainsInLIFOOrder(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	for _, text := range []string{"a", "b", "c"} {
+		require.NoError(t, s.AddMessages(ctx, []message.Message{
+			message.NewUserMessage(text),
+		}))
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	for _, want := range []string{"c", "b", "a"} {
+		popped, err := s.PopMessage(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, popped)
+		assert.Equal(t, want, popped.Content().Text)
+	}
 
 	popped, err := s.PopMessage(ctx)
 	require.NoError(t, err)
@@ -192,12 +297,9 @@ func TestPostgresSession_PopMessageEmpty(t *testing.T) {
 
 func TestPostgresSession_Clear(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
-	require.NoError(t, err)
-
-	s, err := store.Create(ctx, "s1")
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
 	err = s.AddMessages(ctx, []message.Message{
@@ -213,14 +315,84 @@ func TestPostgresSession_Clear(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func TestPostgresSession_PersistsAcrossLoads(t *testing.T) {
+func TestPostgresSession_ClearThenAdd(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
-	s, err := store.Create(ctx, "s1")
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("old"),
+	}))
+	require.NoError(t, s.Clear(ctx))
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("new"),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "new", got[0].Content().Text)
+}
+
+func TestPostgresSession_ClearIsScopedToSession(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s1, err := store.Create(ctx, sessionID(t)+"-1")
+	require.NoError(t, err)
+	s2, err := store.Create(ctx, sessionID(t)+"-2")
+	require.NoError(t, err)
+
+	require.NoError(t, s1.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("from s1"),
+	}))
+	require.NoError(t, s2.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("from s2"),
+	}))
+
+	require.NoError(t, s1.Clear(ctx))
+
+	got1, err := s1.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got1)
+
+	got2, err := s2.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got2, 1)
+	assert.Equal(t, "from s2", got2[0].Content().Text)
+}
+
+func TestPostgresSession_MessagesAreIsolatedBySession(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s1, err := store.Create(ctx, sessionID(t)+"-1")
+	require.NoError(t, err)
+	s2, err := store.Create(ctx, sessionID(t)+"-2")
+	require.NoError(t, err)
+
+	require.NoError(t, s1.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("only in s1"),
+	}))
+
+	got2, err := s2.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got2)
+
+	got1, err := s1.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got1, 1)
+	assert.Equal(t, "only in s1", got1[0].Content().Text)
+}
+
+func TestPostgresSession_PersistsAcrossLoads(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+	id := sessionID(t)
+
+	s, err := store.Create(ctx, id)
 	require.NoError(t, err)
 
 	err = s.AddMessages(ctx, []message.Message{
@@ -228,7 +400,9 @@ func TestPostgresSession_PersistsAcrossLoads(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	loaded, err := store.Load(ctx, "s1")
+	// A fresh store against the same database must see the message.
+	store2 := newStore(t)
+	loaded, err := store2.Load(ctx, id)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 
@@ -240,12 +414,10 @@ func TestPostgresSession_PersistsAcrossLoads(t *testing.T) {
 
 func TestPostgresStore_DeleteRemovesSessionMessages(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
+	id := sessionID(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
-	require.NoError(t, err)
-
-	s, err := store.Create(ctx, "s1")
+	s, err := store.Create(ctx, id)
 	require.NoError(t, err)
 
 	err = s.AddMessages(ctx, []message.Message{
@@ -253,11 +425,11 @@ func TestPostgresStore_DeleteRemovesSessionMessages(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.Delete(ctx, "s1")
+	err = store.Delete(ctx, id)
 	require.NoError(t, err)
 
 	// Recreate the same session ID and verify no old messages remain.
-	s, err = store.Create(ctx, "s1")
+	s, err = store.Create(ctx, id)
 	require.NoError(t, err)
 
 	got, err := s.GetMessages(ctx, nil)
@@ -265,14 +437,39 @@ func TestPostgresStore_DeleteRemovesSessionMessages(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func TestPostgresSession_ToolCallRoundTrip(t *testing.T) {
+func TestPostgresStore_DeleteOnlyAffectsTargetSession(t *testing.T) {
 	ctx := context.Background()
-	connStr := setupPostgres(ctx, t)
+	store := newStore(t)
 
-	store, err := postgres.SessionStore(ctx, connStr)
+	s1, err := store.Create(ctx, sessionID(t)+"-1")
+	require.NoError(t, err)
+	s2, err := store.Create(ctx, sessionID(t)+"-2")
 	require.NoError(t, err)
 
-	s, err := store.Create(ctx, "s1")
+	require.NoError(t, s1.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("s1 message"),
+	}))
+	require.NoError(t, s2.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("s2 message"),
+	}))
+
+	require.NoError(t, store.Delete(ctx, sessionID(t)+"-1"))
+
+	exists, err := store.Exists(ctx, sessionID(t)+"-2")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	got, err := s2.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "s2 message", got[0].Content().Text)
+}
+
+func TestPostgresSession_ToolCallRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
 	require.NoError(t, err)
 
 	msg := message.NewMessage(
@@ -297,4 +494,152 @@ func TestPostgresSession_ToolCallRoundTrip(t *testing.T) {
 	require.Len(t, calls, 1)
 	assert.Equal(t, "search", calls[0].Name)
 	assert.Equal(t, `{"q":"test"}`, calls[0].Input)
+}
+
+func TestPostgresSession_ToolResultRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	msg := message.NewMessage(
+		message.Tool,
+		[]message.ContentPart{
+			message.ToolResult{
+				ToolCallID: "tc_1",
+				Name:       "search",
+				Content:    `{"result":"ok"}`,
+			},
+		},
+	)
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	results := got[0].ToolResults()
+	require.Len(t, results, 1)
+	assert.Equal(t, "tc_1", results[0].ToolCallID)
+	assert.Equal(t, "search", results[0].Name)
+	assert.Equal(t, `{"result":"ok"}`, results[0].Content)
+}
+
+func TestPostgresSession_ModelFieldRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	msg := message.NewUserMessage("hello")
+	msg.Model = "gpt-4o"
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "gpt-4o", string(got[0].Model))
+}
+
+func TestPostgresSession_UnicodeAndSpecialCharacters(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	text := "emoji 🚀, quotes \"'`, unicode café ☕, json {\"k\":1}"
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage(text),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, text, got[0].Content().Text)
+}
+
+func TestPostgresSession_WithIDGenerator(t *testing.T) {
+	ctx := context.Background()
+
+	var counter int
+	var mu sync.Mutex
+	gen := func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		counter++
+		return fmt.Sprintf("%s-msg-%d", t.Name(), counter)
+	}
+
+	store := newStore(t, postgres.WithIDGenerator(gen))
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+		message.NewUserMessage("b"),
+	}))
+
+	assert.Equal(t, 2, counter, "id generator should be called once per message")
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
+func TestPostgresSession_DuplicateIDGeneratorFails(t *testing.T) {
+	ctx := context.Background()
+
+	gen := func() string { return t.Name() + "-constant" }
+	store := newStore(t, postgres.WithIDGenerator(gen))
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	err = s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+		message.NewUserMessage("b"),
+	})
+	require.Error(t, err, "a colliding message id should violate the primary key")
+}
+
+func TestPostgresSession_ConcurrentAddMessages(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	s, err := store.Create(ctx, sessionID(t))
+	require.NoError(t, err)
+
+	const writers = 8
+	const perWriter = 10
+
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for w := range writers {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := range perWriter {
+				err := s.AddMessages(ctx, []message.Message{
+					message.NewUserMessage(fmt.Sprintf("w%d-m%d", w, i)),
+				})
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, got, writers*perWriter)
 }

--- a/memory/sqlite/session.go
+++ b/memory/sqlite/session.go
@@ -55,10 +55,6 @@ func SessionStore(
 		messagesTable,
 	)
 
-	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
-		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
-	}
-
 	if _, err := db.ExecContext(ctx, createSessionsSQL); err != nil {
 		return nil, fmt.Errorf("failed to create sessions table: %w", err)
 	}
@@ -105,9 +101,26 @@ func (s *sessionStore) Load(
 }
 
 func (s *sessionStore) Delete(ctx context.Context, id string) error {
-	query := fmt.Sprintf("DELETE FROM %ssessions WHERE id = ?", s.prefix)
-	_, err := s.db.ExecContext(ctx, query, id)
-	return err
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	deleteMessages := fmt.Sprintf(
+		"DELETE FROM %smessages WHERE session_id = ?",
+		s.prefix,
+	)
+	if _, err := tx.ExecContext(ctx, deleteMessages, id); err != nil {
+		return err
+	}
+
+	deleteSession := fmt.Sprintf("DELETE FROM %ssessions WHERE id = ?", s.prefix)
+	if _, err := tx.ExecContext(ctx, deleteSession, id); err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 type sqliteSession struct {

--- a/memory/sqlite/tests/session_test.go
+++ b/memory/sqlite/tests/session_test.go
@@ -5,18 +5,27 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/joakimcarlsson/ai/memory/sqlite"
 	"github.com/joakimcarlsson/ai/message"
-	_ "modernc.org/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
 
+// setupSQLite returns an in-memory SQLite database suitable for tests.
+//
+// database/sql opens a pool of connections and each connection to ":memory:"
+// gets its own independent database, which can surface as missing tables or
+// empty reads. Capping the pool at a single connection guarantees every
+// operation in a test sees the same in-memory database.
 func setupSQLite(t *testing.T) *sql.DB {
+	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { db.Close() })
 	return db
 }
@@ -58,6 +67,20 @@ func TestSQLiteStore_ExistsMissing(t *testing.T) {
 	assert.False(t, exists)
 }
 
+func TestSQLiteStore_CreateDuplicateFails(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	_, err = store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	_, err = store.Create(ctx, "s1")
+	require.Error(t, err, "creating a session with a duplicate id should fail")
+}
+
 func TestSQLiteStore_Delete(t *testing.T) {
 	ctx := context.Background()
 	db := setupSQLite(t)
@@ -74,6 +97,35 @@ func TestSQLiteStore_Delete(t *testing.T) {
 	exists, err := store.Exists(ctx, "s1")
 	require.NoError(t, err)
 	assert.False(t, exists)
+}
+
+func TestSQLiteStore_DeleteMissingIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	err = store.Delete(ctx, "nonexistent")
+	require.NoError(t, err)
+}
+
+func TestSQLiteStore_LoadMissingReturnsUsableSession(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	// Load does not verify existence; it returns a handle bound to the id.
+	loaded, err := store.Load(ctx, "never-created")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "never-created", loaded.ID())
+
+	got, err := loaded.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }
 
 func TestSQLiteSession_AddAndGetMessages(t *testing.T) {
@@ -102,6 +154,67 @@ func TestSQLiteSession_AddAndGetMessages(t *testing.T) {
 	assert.Equal(t, message.System, got[1].Role)
 }
 
+func TestSQLiteSession_GetMessagesEmpty(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, got, "expected an empty, non-nil slice")
+	assert.Empty(t, got)
+}
+
+func TestSQLiteSession_AddMessagesEmptyBatch(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	err = s.AddMessages(ctx, nil)
+	require.NoError(t, err)
+	err = s.AddMessages(ctx, []message.Message{})
+	require.NoError(t, err)
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestSQLiteSession_AddMessagesPreservesOrder(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	const count = 50
+	batch := make([]message.Message, count)
+	for i := range batch {
+		batch[i] = message.NewUserMessage(fmt.Sprintf("msg %d", i))
+	}
+	require.NoError(t, s.AddMessages(ctx, batch))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, count)
+	for i := range got {
+		assert.Equal(t, fmt.Sprintf("msg %d", i), got[i].Content().Text)
+	}
+}
+
 func TestSQLiteSession_GetMessagesWithLimit(t *testing.T) {
 	ctx := context.Background()
 	db := setupSQLite(t)
@@ -112,7 +225,7 @@ func TestSQLiteSession_GetMessagesWithLimit(t *testing.T) {
 	s, err := store.Create(ctx, "s1")
 	require.NoError(t, err)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err = s.AddMessages(ctx, []message.Message{
 			message.NewUserMessage(fmt.Sprintf("msg %d", i)),
 		})
@@ -125,6 +238,49 @@ func TestSQLiteSession_GetMessagesWithLimit(t *testing.T) {
 	require.Len(t, got, 2)
 	assert.Equal(t, "msg 3", got[0].Content().Text)
 	assert.Equal(t, "msg 4", got[1].Content().Text)
+}
+
+func TestSQLiteSession_GetMessagesLimitExceedsCount(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+		message.NewUserMessage("b"),
+	}))
+
+	limit := 10
+	got, err := s.GetMessages(ctx, &limit)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a", got[0].Content().Text)
+	assert.Equal(t, "b", got[1].Content().Text)
+}
+
+func TestSQLiteSession_GetMessagesLimitZero(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+	}))
+
+	limit := 0
+	got, err := s.GetMessages(ctx, &limit)
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }
 
 func TestSQLiteSession_PopMessage(t *testing.T) {
@@ -169,6 +325,34 @@ func TestSQLiteSession_PopMessageEmpty(t *testing.T) {
 	assert.Nil(t, popped)
 }
 
+func TestSQLiteSession_PopMessageDrainsInLIFOOrder(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+		message.NewUserMessage("b"),
+		message.NewUserMessage("c"),
+	}))
+
+	for _, want := range []string{"c", "b", "a"} {
+		popped, err := s.PopMessage(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, popped)
+		assert.Equal(t, want, popped.Content().Text)
+	}
+
+	popped, err := s.PopMessage(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, popped)
+}
+
 func TestSQLiteSession_Clear(t *testing.T) {
 	ctx := context.Background()
 	db := setupSQLite(t)
@@ -192,6 +376,87 @@ func TestSQLiteSession_Clear(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestSQLiteSession_ClearThenAdd(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("old"),
+	}))
+	require.NoError(t, s.Clear(ctx))
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("new"),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "new", got[0].Content().Text)
+}
+
+func TestSQLiteSession_ClearIsScopedToSession(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s1, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+	s2, err := store.Create(ctx, "s2")
+	require.NoError(t, err)
+
+	require.NoError(t, s1.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("from s1"),
+	}))
+	require.NoError(t, s2.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("from s2"),
+	}))
+
+	require.NoError(t, s1.Clear(ctx))
+
+	got1, err := s1.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got1)
+
+	got2, err := s2.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got2, 1)
+	assert.Equal(t, "from s2", got2[0].Content().Text)
+}
+
+func TestSQLiteSession_MessagesAreIsolatedBySession(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s1, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+	s2, err := store.Create(ctx, "s2")
+	require.NoError(t, err)
+
+	require.NoError(t, s1.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("only in s1"),
+	}))
+
+	got2, err := s2.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got2)
+
+	got1, err := s1.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got1, 1)
+	assert.Equal(t, "only in s1", got1[0].Content().Text)
+}
+
 func TestSQLiteSession_PersistsAcrossLoads(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()
@@ -200,7 +465,7 @@ func TestSQLiteSession_PersistsAcrossLoads(t *testing.T) {
 	// Initial setup
 	db, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
-	
+
 	store, err := sqlite.SessionStore(ctx, db)
 	require.NoError(t, err)
 
@@ -258,6 +523,37 @@ func TestSQLiteStore_DeleteRemovesSessionMessages(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestSQLiteStore_DeleteOnlyAffectsTargetSession(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s1, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+	s2, err := store.Create(ctx, "s2")
+	require.NoError(t, err)
+
+	require.NoError(t, s1.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("s1 message"),
+	}))
+	require.NoError(t, s2.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("s2 message"),
+	}))
+
+	require.NoError(t, store.Delete(ctx, "s1"))
+
+	exists, err := store.Exists(ctx, "s2")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	got, err := s2.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "s2 message", got[0].Content().Text)
+}
+
 func TestSQLiteSession_ToolCallRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	db := setupSQLite(t)
@@ -292,6 +588,80 @@ func TestSQLiteSession_ToolCallRoundTrip(t *testing.T) {
 	assert.Equal(t, `{"q":"test"}`, calls[0].Input)
 }
 
+func TestSQLiteSession_ToolResultRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	msg := message.NewMessage(
+		message.Tool,
+		[]message.ContentPart{
+			message.ToolResult{
+				ToolCallID: "tc_1",
+				Name:       "search",
+				Content:    `{"result":"ok"}`,
+			},
+		},
+	)
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	results := got[0].ToolResults()
+	require.Len(t, results, 1)
+	assert.Equal(t, "tc_1", results[0].ToolCallID)
+	assert.Equal(t, "search", results[0].Name)
+	assert.Equal(t, `{"result":"ok"}`, results[0].Content)
+}
+
+func TestSQLiteSession_ModelFieldRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	msg := message.NewUserMessage("hello")
+	msg.Model = "gpt-4o"
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "gpt-4o", string(got[0].Model))
+}
+
+func TestSQLiteSession_UnicodeAndSpecialCharacters(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	text := "emoji 🚀, quotes \"'`, newlines\n\t, unicode café ☕, json {\"k\":1}"
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage(text),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, text, got[0].Content().Text)
+}
+
 func TestSQLiteStore_Prefix(t *testing.T) {
 	ctx := context.Background()
 	db := setupSQLite(t)
@@ -302,7 +672,89 @@ func TestSQLiteStore_Prefix(t *testing.T) {
 	store2, err := sqlite.SessionStore(ctx, db, sqlite.WithTablePrefix("b_"))
 	require.NoError(t, err)
 
-	_, _ = store1.Create(ctx, "s1")
-	exists, _ := store2.Exists(ctx, "s1")
+	_, err = store1.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	exists, err := store2.Exists(ctx, "s1")
+	require.NoError(t, err)
 	assert.False(t, exists, "session in store A should not exist in store B")
+}
+
+func TestSQLiteStore_PrefixedStoresShareDB(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	storeA, err := sqlite.SessionStore(ctx, db, sqlite.WithTablePrefix("a_"))
+	require.NoError(t, err)
+	storeB, err := sqlite.SessionStore(ctx, db, sqlite.WithTablePrefix("b_"))
+	require.NoError(t, err)
+
+	sa, err := storeA.Create(ctx, "shared")
+	require.NoError(t, err)
+	sb, err := storeB.Create(ctx, "shared")
+	require.NoError(t, err)
+
+	require.NoError(t, sa.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("in A"),
+	}))
+	require.NoError(t, sb.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("in B"),
+	}))
+
+	gotA, err := sa.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, gotA, 1)
+	assert.Equal(t, "in A", gotA[0].Content().Text)
+
+	gotB, err := sb.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, gotB, 1)
+	assert.Equal(t, "in B", gotB[0].Content().Text)
+
+	// Deleting in A must not touch B's identically-named session.
+	require.NoError(t, storeA.Delete(ctx, "shared"))
+	existsB, err := storeB.Exists(ctx, "shared")
+	require.NoError(t, err)
+	assert.True(t, existsB)
+}
+
+func TestSQLiteSession_ConcurrentAddMessages(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	const writers = 8
+	const perWriter = 10
+
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for w := range writers {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := range perWriter {
+				err := s.AddMessages(ctx, []message.Message{
+					message.NewUserMessage(fmt.Sprintf("w%d-m%d", w, i)),
+				})
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, got, writers*perWriter)
 }

--- a/memory/sqlite/tests/session_test.go
+++ b/memory/sqlite/tests/session_test.go
@@ -1,10 +1,12 @@
 package sqlite_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -117,7 +119,6 @@ func TestSQLiteStore_LoadMissingReturnsUsableSession(t *testing.T) {
 	store, err := sqlite.SessionStore(ctx, db)
 	require.NoError(t, err)
 
-	// Load does not verify existence; it returns a handle bound to the id.
 	loaded, err := store.Load(ctx, "never-created")
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
@@ -462,7 +463,6 @@ func TestSQLiteSession_PersistsAcrossLoads(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
-	// Initial setup
 	db, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
 
@@ -478,7 +478,6 @@ func TestSQLiteSession_PersistsAcrossLoads(t *testing.T) {
 	require.NoError(t, err)
 	db.Close()
 
-	// Reload from the same file
 	db2, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
 	defer db2.Close()
@@ -514,7 +513,6 @@ func TestSQLiteStore_DeleteRemovesSessionMessages(t *testing.T) {
 	err = store.Delete(ctx, "s1")
 	require.NoError(t, err)
 
-	// Recreate the same session ID and verify no old messages remain.
 	s, err = store.Create(ctx, "s1")
 	require.NoError(t, err)
 
@@ -711,7 +709,6 @@ func TestSQLiteStore_PrefixedStoresShareDB(t *testing.T) {
 	require.Len(t, gotB, 1)
 	assert.Equal(t, "in B", gotB[0].Content().Text)
 
-	// Deleting in A must not touch B's identically-named session.
 	require.NoError(t, storeA.Delete(ctx, "shared"))
 	existsB, err := storeB.Exists(ctx, "shared")
 	require.NoError(t, err)
@@ -757,4 +754,281 @@ func TestSQLiteSession_ConcurrentAddMessages(t *testing.T) {
 	got, err := s.GetMessages(ctx, nil)
 	require.NoError(t, err)
 	assert.Len(t, got, writers*perWriter)
+}
+
+func TestSQLiteSession_GetMessagesNegativeLimit(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("a"),
+		message.NewUserMessage("b"),
+	}))
+
+	limit := -1
+	got, err := s.GetMessages(ctx, &limit)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a", got[0].Content().Text)
+	assert.Equal(t, "b", got[1].Content().Text)
+}
+
+func TestSQLiteSession_CreatedAtRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	msg := message.NewUserMessage("hello")
+	msg.CreatedAt = 1_700_000_000_000_000_000
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(1_700_000_000_000_000_000), got[0].CreatedAt)
+}
+
+func TestSQLiteSession_LargeContentRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	large := strings.Repeat("lorem ipsum ", 100_000)
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage(large),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, large, got[0].Content().Text)
+}
+
+func TestSQLiteSession_MultipleToolCallsInOneMessage(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	msg := message.NewMessage(message.Assistant, []message.ContentPart{
+		message.TextContent{Text: "running tools"},
+		message.ToolCall{ID: "tc_1", Name: "search", Input: `{"q":"a"}`},
+		message.ToolCall{ID: "tc_2", Name: "lookup", Input: `{"id":2}`},
+	})
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	calls := got[0].ToolCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, "search", calls[0].Name)
+	assert.Equal(t, "tc_2", calls[1].ID)
+	assert.Equal(t, "running tools", got[0].Content().Text)
+}
+
+func TestSQLiteSession_ImageURLRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	msg := message.NewMessage(message.User, []message.ContentPart{
+		message.TextContent{Text: "look"},
+		message.ImageURLContent{URL: "https://example.com/cat.png", Detail: "high"},
+	})
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	images := got[0].ImageURLContent()
+	require.Len(t, images, 1)
+	assert.Equal(t, "https://example.com/cat.png", images[0].URL)
+	assert.Equal(t, "high", images[0].Detail)
+}
+
+func TestSQLiteSession_BinaryContentRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	data := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	msg := message.NewMessage(message.User, []message.ContentPart{
+		message.BinaryContent{MIMEType: "application/octet-stream", Data: data},
+	})
+	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	bin := got[0].BinaryContent()
+	require.Len(t, bin, 1)
+	assert.Equal(t, "application/octet-stream", bin[0].MIMEType)
+	assert.True(t, bytes.Equal(data, bin[0].Data))
+}
+
+func TestSQLiteSession_SummaryRoleRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewSummaryMessage("conversation summary"),
+	}))
+
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, message.Summary, got[0].Role)
+	assert.Equal(t, "conversation summary", got[0].Content().Text)
+}
+
+func TestSQLiteSession_EmptySessionID(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	s, err := store.Create(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, "", s.ID())
+
+	exists, err := store.Exists(ctx, "")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("empty id"),
+	}))
+	got, err := s.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+}
+
+func TestSQLiteStore_ManySessions(t *testing.T) {
+	ctx := context.Background()
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+
+	const n = 100
+	for i := range n {
+		id := fmt.Sprintf("s%d", i)
+		s, err := store.Create(ctx, id)
+		require.NoError(t, err)
+		require.NoError(t, s.AddMessages(ctx, []message.Message{
+			message.NewUserMessage(fmt.Sprintf("hello %d", i)),
+		}))
+	}
+
+	for i := range n {
+		id := fmt.Sprintf("s%d", i)
+		exists, err := store.Exists(ctx, id)
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		s, err := store.Load(ctx, id)
+		require.NoError(t, err)
+		got, err := s.GetMessages(ctx, nil)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, fmt.Sprintf("hello %d", i), got[0].Content().Text)
+	}
+}
+
+func TestSQLiteSession_ContextCancellation(t *testing.T) {
+	db := setupSQLite(t)
+
+	store, err := sqlite.SessionStore(context.Background(), db)
+	require.NoError(t, err)
+
+	s, err := store.Create(context.Background(), "s1")
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = s.AddMessages(canceled, []message.Message{
+		message.NewUserMessage("nope"),
+	})
+	require.Error(t, err)
+
+	_, err = s.GetMessages(canceled, nil)
+	require.Error(t, err)
+
+	_, err = s.PopMessage(canceled)
+	require.Error(t, err)
+}
+
+func TestSQLiteSession_PersistsAndAppendsAcrossReopen(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "reopen.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	store, err := sqlite.SessionStore(ctx, db)
+	require.NoError(t, err)
+	s, err := store.Create(ctx, "s1")
+	require.NoError(t, err)
+	require.NoError(t, s.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("first"),
+	}))
+	require.NoError(t, db.Close())
+
+	db2, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer db2.Close()
+	store2, err := sqlite.SessionStore(ctx, db2)
+	require.NoError(t, err)
+	s2, err := store2.Load(ctx, "s1")
+	require.NoError(t, err)
+	require.NoError(t, s2.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("second"),
+	}))
+
+	got, err := s2.GetMessages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "first", got[0].Content().Text)
+	assert.Equal(t, "second", got[1].Content().Text)
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -51,8 +51,8 @@ discover_modules() {
 	find . -name 'go.mod' -not -path './.git/*' -not -path './examples/*' -print0 |
 		xargs -0 -n1 dirname |
 		sed 's|^\./||' |
-		grep -v '^\.$' |
-		grep -v '/tests$' || true
+		{ grep -v '^\.$' || true; } |
+		{ grep -v '/tests$' || true; }
 }
 
 # module_path — print "github.com/joakimcarlsson/ai/<dir>" for a module dir.


### PR DESCRIPTION
This pull request introduces improvements to session deletion logic in the SQLite-backed session store and makes a minor fix to the module discovery script used in releases. The most significant change is ensuring that when a session is deleted, all associated messages are also deleted within a transaction, improving data integrity.