### PR TITLE
fix(summarize): prevent re-summarization after compaction

### DIFF
--- a/agent/messages.go
+++ b/agent/messages.go
@@ -115,6 +115,9 @@ func (a *Agent) buildMessages(
 		}
 	}
 
+	userMsg := message.NewUserMessage(userMessage)
+	userMsg.Model = a.llm.Model().ID
+
 	var sessionMessages []message.Message
 	if a.session != nil {
 		var err error
@@ -130,21 +133,11 @@ func (a *Agent) buildMessages(
 		messages = append(messages, sysMsg)
 	}
 
+	// 1. Fully construct the logical state of the conversation (History + New Msg)
 	messages = append(messages, sessionMessages...)
-
-	userMsg := message.NewUserMessage(userMessage)
-	userMsg.Model = a.llm.Model().ID
 	messages = append(messages, userMsg)
 
-	if a.session != nil {
-		if err := a.session.AddMessages(
-			ctx,
-			[]message.Message{userMsg},
-		); err != nil {
-			return nil, err
-		}
-	}
-
+	// 2. Evaluate Strategy
 	if a.contextStrategy != nil {
 		counter, err := tokens.NewCounter()
 		if err != nil {
@@ -171,16 +164,80 @@ func (a *Agent) buildMessages(
 			return nil, fmt.Errorf("context strategy failed: %w", err)
 		}
 
-		messages = result.Messages
+		// 3. Apply Persistence Updates
+		if a.session != nil {
+			if result.SessionUpdate != nil {
+				// The Strategy evaluated [History..., UserMsg].
+				// Its PopCount represents the number of messages to remove from that array.
+				// However, UserMsg is not physically in the Session Store yet.
+				// We must adjust the PopCount to determine how many physical session messages to pop.
 
-		if result.SessionUpdate != nil && a.session != nil &&
-			len(result.SessionUpdate.AddMessages) > 0 {
-			if err := a.session.AddMessages(
-				ctx,
-				result.SessionUpdate.AddMessages,
-			); err != nil {
-				return nil, fmt.Errorf("failed to save session update: %w", err)
+				popCount := result.SessionUpdate.PopCount
+				userMsgIncludedInKeep := false
+
+				if len(result.SessionUpdate.AddMessages) > 0 {
+					lastAdded := result.SessionUpdate.AddMessages[len(result.SessionUpdate.AddMessages)-1]
+					if lastAdded.CreatedAt == userMsg.CreatedAt &&
+						lastAdded.Role == userMsg.Role {
+						userMsgIncludedInKeep = true
+					}
+				}
+
+				if userMsgIncludedInKeep {
+					// The strategy 'popped' UserMsg logically as part of PopCount,
+					// but since it's not in the DB, we shouldn't pop a DB row for it.
+					popCount--
+				}
+
+				for i := 0; i < popCount; i++ {
+					if _, err := a.session.PopMessage(ctx); err != nil {
+						return nil, fmt.Errorf("failed to pop message: %w", err)
+					}
+				}
+
+				if len(result.SessionUpdate.AddMessages) > 0 {
+					if err := a.session.AddMessages(
+						ctx,
+						result.SessionUpdate.AddMessages,
+					); err != nil {
+						return nil, fmt.Errorf(
+							"failed to save session update: %w",
+							err,
+						)
+					}
+				}
+
+				// If userMsg wasn't included in the strategy's update (e.g. truncated),
+				// we still need to persist it normally as the latest action.
+				// But wait, if it was included in AddMessages, userMsgIncludedInKeep is true, we don't save it again.
+				// If it wasn't, we DO save it.
+				if !userMsgIncludedInKeep {
+					if err := a.session.AddMessages(
+						ctx,
+						[]message.Message{userMsg},
+					); err != nil {
+						return nil, err
+					}
+				}
+
+			} else {
+				// No session update needed from strategy, just add the new user message.
+				if err := a.session.AddMessages(
+					ctx,
+					[]message.Message{userMsg},
+				); err != nil {
+					return nil, err
+				}
 			}
+		}
+
+		messages = result.Messages
+	} else if a.session != nil {
+		if err := a.session.AddMessages(
+			ctx,
+			[]message.Message{userMsg},
+		); err != nil {
+			return nil, err
 		}
 	}
 
@@ -239,17 +296,27 @@ func (a *Agent) buildContinueMessages(
 			return nil, fmt.Errorf("context strategy failed: %w", err)
 		}
 
-		messages = result.Messages
+		if result.SessionUpdate != nil && a.session != nil {
+			for i := 0; i < result.SessionUpdate.PopCount; i++ {
+				if _, err := a.session.PopMessage(ctx); err != nil {
+					return nil, fmt.Errorf("failed to pop message: %w", err)
+				}
+			}
 
-		if result.SessionUpdate != nil && a.session != nil &&
-			len(result.SessionUpdate.AddMessages) > 0 {
-			if err := a.session.AddMessages(
-				ctx,
-				result.SessionUpdate.AddMessages,
-			); err != nil {
-				return nil, fmt.Errorf("failed to save session update: %w", err)
+			if len(result.SessionUpdate.AddMessages) > 0 {
+				if err := a.session.AddMessages(
+					ctx,
+					result.SessionUpdate.AddMessages,
+				); err != nil {
+					return nil, fmt.Errorf(
+						"failed to save session update: %w",
+						err,
+					)
+				}
 			}
 		}
+
+		messages = result.Messages
 	}
 
 	return messages, nil

--- a/memory/postgres/tests/session_test.go
+++ b/memory/postgres/tests/session_test.go
@@ -62,7 +62,10 @@ func TestMain(m *testing.M) {
 // newStore returns a session store backed by the shared container.
 func newStore(t *testing.T, opts ...postgres.Option) session.Store {
 	t.Helper()
-	store, err := postgres.SessionStore(context.Background(), sharedConnStr, opts...)
+	store, err := postgres.SessionStore(
+		context.Background(),
+		sharedConnStr,
+		opts...)
 	require.NoError(t, err)
 	return store
 }
@@ -582,7 +585,12 @@ func TestPostgresSession_WithIDGenerator(t *testing.T) {
 		message.NewUserMessage("b"),
 	}))
 
-	assert.Equal(t, 2, counter, "id generator should be called once per message")
+	assert.Equal(
+		t,
+		2,
+		counter,
+		"id generator should be called once per message",
+	)
 
 	got, err := s.GetMessages(ctx, nil)
 	require.NoError(t, err)
@@ -602,7 +610,11 @@ func TestPostgresSession_DuplicateIDGeneratorFails(t *testing.T) {
 		message.NewUserMessage("a"),
 		message.NewUserMessage("b"),
 	})
-	require.Error(t, err, "a colliding message id should violate the primary key")
+	require.Error(
+		t,
+		err,
+		"a colliding message id should violate the primary key",
+	)
 }
 
 func TestPostgresSession_ConcurrentAddMessages(t *testing.T) {
@@ -728,7 +740,10 @@ func TestPostgresSession_ImageURLRoundTrip(t *testing.T) {
 
 	msg := message.NewMessage(message.User, []message.ContentPart{
 		message.TextContent{Text: "look"},
-		message.ImageURLContent{URL: "https://example.com/cat.png", Detail: "high"},
+		message.ImageURLContent{
+			URL:    "https://example.com/cat.png",
+			Detail: "high",
+		},
 	})
 	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
 

--- a/memory/sqlite/session.go
+++ b/memory/sqlite/session.go
@@ -115,7 +115,10 @@ func (s *sessionStore) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	deleteSession := fmt.Sprintf("DELETE FROM %ssessions WHERE id = ?", s.prefix)
+	deleteSession := fmt.Sprintf(
+		"DELETE FROM %ssessions WHERE id = ?",
+		s.prefix,
+	)
 	if _, err := tx.ExecContext(ctx, deleteSession, id); err != nil {
 		return err
 	}

--- a/memory/sqlite/tests/session_test.go
+++ b/memory/sqlite/tests/session_test.go
@@ -860,7 +860,10 @@ func TestSQLiteSession_ImageURLRoundTrip(t *testing.T) {
 
 	msg := message.NewMessage(message.User, []message.ContentPart{
 		message.TextContent{Text: "look"},
-		message.ImageURLContent{URL: "https://example.com/cat.png", Detail: "high"},
+		message.ImageURLContent{
+			URL:    "https://example.com/cat.png",
+			Detail: "high",
+		},
 	})
 	require.NoError(t, s.AddMessages(ctx, []message.Message{msg}))
 

--- a/tests/agent/persistence_test.go
+++ b/tests/agent/persistence_test.go
@@ -1,0 +1,168 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
+	"github.com/joakimcarlsson/ai/tokens"
+)
+
+type mockStrategy struct {
+	popCount    int
+	addMessages []message.Message
+}
+
+func (s *mockStrategy) Fit(
+	ctx context.Context,
+	input tokens.StrategyInput,
+) (*tokens.StrategyResult, error) {
+	return &tokens.StrategyResult{
+		Messages: input.Messages,
+		SessionUpdate: &tokens.SessionUpdate{
+			PopCount:    s.popCount,
+			AddMessages: s.addMessages,
+		},
+	}, nil
+}
+
+func TestAgent_PersistenceWithPopCount(t *testing.T) {
+	ctx := context.Background()
+	store := session.MemoryStore()
+	sess, _ := store.Create(ctx, "test-session")
+
+	// Pre-fill session with some messages
+	resp1 := message.NewAssistantMessage()
+	resp1.AppendContent("Resp 1")
+	sess.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("Msg 1"),
+		resp1,
+		message.NewUserMessage("Msg 2"),
+	})
+
+	a := agent.New(newMockLLM(mockResponse{Content: "Mock response"}),
+		agent.WithSession("test-session", store),
+		agent.WithContextStrategy(&mockStrategy{
+			popCount: 1, // Remove "Msg 2"
+			addMessages: []message.Message{
+				message.NewSummaryMessage("Summary of 1 and Resp 1"),
+				message.NewUserMessage("Msg 2 re-anchored"),
+			},
+		}, 10000),
+	)
+
+	// This should trigger buildMessages which applies the strategy
+	_, err := a.Chat(ctx, "Msg 3")
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+
+	// We need to get the session from the store again to see updates
+	updatedSess, _ := store.Load(ctx, "test-session")
+	msgs, _ := updatedSess.GetMessages(ctx, nil)
+
+	// Expected messages:
+	// 0: Msg 1
+	// 1: Resp 1
+	// (Msg 2 was popped)
+	// 2: Summary of 1 and Resp 1
+	// 3: Msg 2 re-anchored
+	// 4: Msg 3 (the current user message)
+	// 5: Mock response (from assistant)
+
+	if len(msgs) != 6 {
+		t.Errorf("expected 6 messages in session, got %d", len(msgs))
+		for i, m := range msgs {
+			t.Logf("%d: %s - %s", i, m.Role, m.Content().Text)
+		}
+	} else {
+		if msgs[2].Role != message.Summary {
+			t.Errorf("expected msg 2 to be Summary, got %s", msgs[2].Role)
+		}
+		if msgs[3].Content().Text != "Msg 2 re-anchored" {
+			t.Errorf(
+				"expected msg 3 to be 'Msg 2 re-anchored', got %s",
+				msgs[3].Content().Text,
+			)
+		}
+		if msgs[4].Content().Text != "Msg 3" {
+			t.Errorf(
+				"expected msg 4 to be 'Msg 3', got %s",
+				msgs[4].Content().Text,
+			)
+		}
+	}
+}
+
+func TestAgent_PersistenceWithPopCount_Continue(t *testing.T) {
+	ctx := context.Background()
+	store := session.MemoryStore()
+	sess, _ := store.Create(ctx, "test-session-continue")
+
+	// Pre-fill session with some messages
+	resp1 := message.NewAssistantMessage()
+	resp1.AppendContent("Resp 1")
+	sess.AddMessages(ctx, []message.Message{
+		message.NewUserMessage("Msg 1"),
+		resp1,
+		message.NewUserMessage("Msg 2"),
+	})
+
+	a := agent.New(newMockLLM(mockResponse{Content: "Mock response"}),
+		agent.WithSession("test-session-continue", store),
+		agent.WithContextStrategy(&mockStrategy{
+			popCount: 1, // Remove "Msg 2"
+			addMessages: []message.Message{
+				message.NewSummaryMessage("Summary of 1 and Resp 1"),
+				message.NewUserMessage("Msg 2 re-anchored"),
+			},
+		}, 10000),
+	)
+
+	// This should trigger buildContinueMessages which applies the strategy.
+	// We need to provide a tool result since Continue requires it.
+	_, err := a.Continue(ctx, []message.ToolResult{
+		{
+			ToolCallID: "call_1",
+			Content:    "result",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Continue failed: %v", err)
+	}
+
+	// We need to get the session from the store again to see updates
+	updatedSess, _ := store.Load(ctx, "test-session-continue")
+	msgs, _ := updatedSess.GetMessages(ctx, nil)
+
+	// Expected messages:
+	// 0: Msg 1
+	// 1: Resp 1
+	// (Msg 2 was popped)
+	// 2: Summary of 1 and Resp 1
+	// 3: Msg 2 re-anchored
+	// 4: Tool result (added by Continue)
+	// 5: Mock response (from assistant, because it's a continue)
+
+	if len(msgs) != 6 {
+		t.Errorf("expected 6 messages in session, got %d", len(msgs))
+		for i, m := range msgs {
+			t.Logf("%d: %s - %s", i, m.Role, m.Content().Text)
+		}
+	} else {
+		if msgs[2].Role != message.Summary {
+			t.Errorf("expected msg 2 to be Summary, got %s", msgs[2].Role)
+		}
+		if msgs[3].Content().Text != "Msg 2 re-anchored" {
+			t.Errorf(
+				"expected msg 3 to be 'Msg 2 re-anchored', got %s",
+				msgs[3].Content().Text,
+			)
+		}
+		if msgs[5].Role != message.Assistant {
+			t.Errorf("expected msg 5 to be Assistant, got %s", msgs[5].Role)
+		}
+	}
+}

--- a/tests/agent/summarize_test.go
+++ b/tests/agent/summarize_test.go
@@ -1,0 +1,142 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
+	"github.com/joakimcarlsson/ai/tokens/summarize"
+)
+
+func TestAgent_SummarizeStrategy(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Setup separate mock LLMs for the summarizer and the agent.
+	summarizerLLM := newMockLLM(
+		mockResponse{
+			Content:      "This is a summary of the first turn.",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+	)
+	mockAgentLLM := newMockLLM(
+		// Response for turn 1
+		mockResponse{
+			Content:      "Response 1",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+		// Response for turn 2 (which will include the summary)
+		mockResponse{
+			Content:      "I've received the summary and your new message.",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+	)
+
+	store := session.MemoryStore()
+
+	// Create a strategy with a low "KeepRecent"
+	strat := summarize.Strategy(summarizerLLM, summarize.KeepRecent(1))
+
+	a := agent.New(mockAgentLLM,
+		agent.WithSession("test-session", store),
+		agent.WithSystemPrompt("You are a test assistant."),
+		// Force summary by setting a very low limit.
+		// Token count for "Message 1" + system prompt + overhead will easily exceed 20.
+		agent.WithContextStrategy(strat, 20),
+	)
+
+	// 2. First turn.
+	// Fit will see: [System, Message 1]. convMsgs = [Message 1].
+	// splitPoint = 1 - 1 = 0. No summary triggered.
+	_, err := a.Chat(ctx, "Message 1")
+	if err != nil {
+		t.Fatalf("Turn 1 failed: %v", err)
+	}
+
+	// 3. Second turn.
+	// Fit will see: [System, Message 1, Response 1, New Message].
+	// convMsgs = [Message 1, Response 1, New Message].
+	// splitPoint = 3 - 1 = 2.
+	// Summarizes: [Message 1, Response 1].
+	resp, err := a.Chat(ctx, "New Message")
+	if err != nil {
+		t.Fatalf("Turn 2 failed: %v", err)
+	}
+
+	if !strings.Contains(resp.Content, "I've received the summary") {
+		t.Errorf(
+			"Expected response acknowledging summary, got %q",
+			resp.Content,
+		)
+	}
+
+	// 4. Verify session state.
+	sess, _ := store.Load(ctx, "test-session")
+	sessMsgs, err := sess.GetMessages(ctx, nil)
+	if err != nil {
+		t.Fatalf("Failed to get session messages: %v", err)
+	}
+
+	// Expected session messages:
+	// 1. User: Message 1
+	// 2. Assistant: Response 1
+	// 3. Summary: This is a summary...
+	// 4. User: New Message
+	// 5. Assistant: I've received the summary...
+	if len(sessMsgs) != 5 {
+		t.Errorf("Expected 5 messages in session, got %d", len(sessMsgs))
+	}
+
+	hasSummary := false
+	for _, m := range sessMsgs {
+		if m.Role == message.Summary {
+			hasSummary = true
+			if !strings.Contains(m.Content().Text, "This is a summary") {
+				t.Errorf("Unexpected summary content: %q", m.Content().Text)
+			}
+		}
+	}
+
+	if !hasSummary {
+		t.Error("Session store does not contain a summary message")
+	}
+
+	// 5. Verify LLM calls.
+
+	// Agent should have 2 chat calls.
+	if mockAgentLLM.CallCount() != 2 {
+		t.Errorf("Expected 2 Agent LLM calls, got %d", mockAgentLLM.CallCount())
+	}
+
+	// Summarizer should have 1 call.
+	if summarizerLLM.CallCount() != 1 {
+		t.Errorf(
+			"Expected 1 Summarizer LLM call, got %d",
+			summarizerLLM.CallCount(),
+		)
+	}
+
+	// Verify turn 2 LLM prompt received the summary.
+	agentTurn2Msgs := mockAgentLLM.calls[1]
+	foundSummaryInPrompt := false
+	foundOldMsgInPrompt := false
+	for _, m := range agentTurn2Msgs {
+		if strings.Contains(m.Content().Text, "This is a summary") {
+			foundSummaryInPrompt = true
+		}
+		if strings.Contains(m.Content().Text, "Message 1") {
+			foundOldMsgInPrompt = true
+		}
+	}
+
+	if !foundSummaryInPrompt {
+		t.Error("Summary was not sent to the Agent LLM in Turn 2")
+	}
+	if foundOldMsgInPrompt {
+		t.Error(
+			"Old message 1 was sent to the Agent LLM in Turn 2 despite being summarized",
+		)
+	}
+}

--- a/tests/session/strategy_integration_test.go
+++ b/tests/session/strategy_integration_test.go
@@ -1,0 +1,120 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
+	"github.com/joakimcarlsson/ai/tokens/summarize"
+)
+
+// runSummarizeStrategyTest drives a real agent.Agent backed by the given store,
+// chatting until the summarize strategy compacts the history, then verifies the
+// store persisted the compaction correctly. Running it against both FileStore and
+// MemoryStore exercises summary-message round-tripping through each backend via
+// the actual agent persistence path (PopCount + AddMessages), rather than a
+// hand-simulated session update.
+func runSummarizeStrategyTest(t *testing.T, store session.Store) {
+	ctx := context.Background()
+
+	const sessionID = "strategy-test"
+	summarizer := &bugMockSummarizer{}
+	// Keep only the most recent message so a summary triggers quickly.
+	strat := summarize.Strategy(summarizer, summarize.KeepRecent(1))
+
+	a := agent.New(
+		&mockAgentLLM{t: t},
+		agent.WithSession(sessionID, store),
+		agent.WithContextStrategy(strat, 100),
+	)
+
+	// Chat until the active context exceeds the limit and a summary is produced.
+	turn := 1
+	for summarizer.callCount == 0 && turn <= 10 {
+		msg := fmt.Sprintf(
+			"Hello, this is message %d. Please remember it.",
+			turn,
+		)
+		if _, err := a.Chat(ctx, msg); err != nil {
+			t.Fatalf("Chat turn %d failed: %v", turn, err)
+		}
+		turn++
+	}
+	if summarizer.callCount == 0 {
+		t.Fatal("expected summarizer to be triggered within 10 turns")
+	}
+
+	// Reload from the store to confirm the compaction round-trips through the backend.
+	sess, err := store.Load(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	saved, err := sess.GetMessages(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to get saved messages: %v", err)
+	}
+
+	// Exactly one summary message should be persisted, with the expected content.
+	summaryCount := 0
+	summaryIdx := -1
+	for i, m := range saved {
+		if m.Role == message.Summary {
+			summaryCount++
+			summaryIdx = i
+		}
+	}
+	if summaryCount != 1 {
+		t.Fatalf(
+			"expected exactly 1 persisted summary message, got %d",
+			summaryCount,
+		)
+	}
+	if !strings.Contains(
+		saved[summaryIdx].Content().Text,
+		"This is the summary content",
+	) {
+		t.Errorf(
+			"unexpected summary content: %q",
+			saved[summaryIdx].Content().Text,
+		)
+	}
+
+	// A fresh agent on the same store+id reloads the session from the backend
+	// (for FileStore this deserializes from disk). The persisted Summary acts as
+	// an anchor: a short follow-up must fit and must NOT re-trigger summarization.
+	// If the backend dropped the Summary role on round-trip, the anchor would be
+	// lost and the strategy would summarize again, failing this assertion.
+	summarizer.callCount = 0
+	reloaded := agent.New(
+		&mockAgentLLM{t: t},
+		agent.WithSession(sessionID, store),
+		agent.WithContextStrategy(strat, 100),
+	)
+	if _, err := reloaded.Chat(ctx, "Short follow-up"); err != nil {
+		t.Fatalf("follow-up chat failed: %v", err)
+	}
+	if summarizer.callCount != 0 {
+		t.Errorf(
+			"summarizer re-triggered after reload on a turn that fits (called %d times)",
+			summarizer.callCount,
+		)
+	}
+}
+
+func TestFileSession_SummarizeStrategy(t *testing.T) {
+	dir := t.TempDir()
+	store := session.FileStore(dir)
+	if store == nil {
+		t.Fatal("failed to create FileStore")
+	}
+	runSummarizeStrategyTest(t, store)
+}
+
+func TestMemorySession_SummarizeStrategy(t *testing.T) {
+	store := session.MemoryStore()
+	runSummarizeStrategyTest(t, store)
+}

--- a/tests/session/summarize_bug_test.go
+++ b/tests/session/summarize_bug_test.go
@@ -1,0 +1,188 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/agent"
+	llm "github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/schema"
+	"github.com/joakimcarlsson/ai/session"
+	"github.com/joakimcarlsson/ai/tokens"
+	"github.com/joakimcarlsson/ai/tokens/summarize"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type bugMockSummarizer struct {
+	callCount int
+	lastMsgs  []message.Message
+}
+
+func (m *bugMockSummarizer) SendMessages(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+) (*llm.Response, error) {
+	m.callCount++
+	m.lastMsgs = msgs
+	return &llm.Response{
+		Content: "This is the summary content. It replaces the previous messages to save space.",
+	}, nil
+}
+
+func (m *bugMockSummarizer) SendMessagesWithStructuredOutput(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+	outputSchema *schema.StructuredOutputInfo,
+) (*llm.Response, error) {
+	return nil, nil
+}
+
+func (m *bugMockSummarizer) StreamResponse(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+) <-chan llm.Event {
+	return nil
+}
+
+func (m *bugMockSummarizer) StreamResponseWithStructuredOutput(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+	outputSchema *schema.StructuredOutputInfo,
+) <-chan llm.Event {
+	return nil
+}
+
+func (m *bugMockSummarizer) Model() model.Model {
+	return model.Model{ID: "mock-summarizer"}
+}
+
+func (m *bugMockSummarizer) SupportsStructuredOutput() bool {
+	return false
+}
+
+// mockAgentLLM acts as the primary LLM for the agent
+type mockAgentLLM struct {
+	t *testing.T
+}
+
+func (m *mockAgentLLM) SendMessages(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+) (*llm.Response, error) {
+	m.t.Logf("--> mockAgentLLM called with %d messages", len(msgs))
+	return &llm.Response{
+		Content: "Agent Response",
+	}, nil
+}
+
+func (m *mockAgentLLM) SendMessagesWithStructuredOutput(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+	outputSchema *schema.StructuredOutputInfo,
+) (*llm.Response, error) {
+	return nil, nil
+}
+
+func (m *mockAgentLLM) StreamResponse(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+) <-chan llm.Event {
+	return nil
+}
+
+func (m *mockAgentLLM) StreamResponseWithStructuredOutput(
+	ctx context.Context,
+	msgs []message.Message,
+	tools []tool.BaseTool,
+	outputSchema *schema.StructuredOutputInfo,
+) <-chan llm.Event {
+	return nil
+}
+
+func (m *mockAgentLLM) Model() model.Model {
+	return model.Model{ID: "mock-agent-llm"}
+}
+
+func (m *mockAgentLLM) SupportsStructuredOutput() bool {
+	return false
+}
+
+func TestSummarizeStrategy_ReproductionBug(t *testing.T) {
+	ctx := context.Background()
+	store := session.MemoryStore()
+
+	summarizer := &bugMockSummarizer{}
+	// Keep 1 most recent message pair.
+	strat := summarize.Strategy(summarizer, summarize.KeepRecent(1))
+
+	a := agent.New(
+		&mockAgentLLM{t: t},
+		agent.WithSession("bug-test2", store),
+		agent.WithContextStrategy(strat, 100),
+	)
+
+	// Chat until we trigger a summary
+	turn := 1
+	for summarizer.callCount == 0 && turn <= 10 {
+		msg := fmt.Sprintf(
+			"Hello, this is message %d. Please remember it.",
+			turn,
+		)
+		_, err := a.Chat(ctx, msg)
+		if err != nil {
+			t.Fatalf("Chat failed: %v", err)
+		}
+		turn++
+	}
+
+	if summarizer.callCount == 0 {
+		t.Fatalf(
+			"Expected summary to be triggered, but it was not after 10 turns.",
+		)
+	}
+
+	sess, _ := store.Load(ctx, "bug-test2")
+	rawMsgs, _ := sess.GetMessages(ctx, nil)
+	t.Logf("Session State before Next Turn: %d messages", len(rawMsgs))
+	for i, m := range rawMsgs {
+		t.Logf(" - Session[%d] %s: %s", i, m.Role, m.Content().Text)
+	}
+
+	// Critical check for continuous re-summarization
+	// Active context = [Summary, Kept Assistant, New Msg].
+	// Should fit well within 100 tokens.
+	t.Logf("--- Turn %d (Checking Compaction) ---", turn)
+	summarizer.callCount = 0
+
+	peekMsgs, _ := a.PeekContextMessages(ctx, "Short M4")
+	t.Logf("Peek: %d messages evaluated", len(peekMsgs))
+	for i, m := range peekMsgs {
+		t.Logf(" - [%d] %s: %s", i, m.Role, m.Content().Text)
+	}
+
+	c, _ := tokens.NewCounter()
+	count, _ := c.CountTokens(ctx, tokens.CountOptions{Messages: peekMsgs})
+	t.Logf("Peek actual tokens: %d", count.TotalTokens)
+
+	_, err := a.Chat(ctx, "Short M4")
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+
+	if summarizer.callCount != 0 {
+		t.Errorf(
+			"Bug 1 Confirmed: Summary triggered again even though active context should fit. Summarizer called %d times.",
+			summarizer.callCount,
+		)
+	}
+}

--- a/tokens/strategy.go
+++ b/tokens/strategy.go
@@ -24,6 +24,9 @@ type StrategyResult struct {
 
 // SessionUpdate contains messages to persist to the session.
 type SessionUpdate struct {
+	// PopCount indicates how many messages to remove from the end of the
+	// session before applying AddMessages.
+	PopCount int
 	// AddMessages appends messages to the session.
 	// The full conversation history is preserved for auditing.
 	AddMessages []message.Message

--- a/tokens/summarize/strategy.go
+++ b/tokens/summarize/strategy.go
@@ -35,8 +35,31 @@ func (s *summarizeStrategy) Fit(
 	ctx context.Context,
 	input tokens.StrategyInput,
 ) (*tokens.StrategyResult, error) {
+	// 1. Identify active context (System messages + messages since last summary)
+	activeMessages := make([]message.Message, 0, len(input.Messages))
+	lastSummaryIdx := -1
+	for i := len(input.Messages) - 1; i >= 0; i-- {
+		if input.Messages[i].Role == message.Summary {
+			lastSummaryIdx = i
+			break
+		}
+	}
+
+	for i, msg := range input.Messages {
+		if msg.Role == message.System {
+			activeMessages = append(activeMessages, msg)
+		} else if lastSummaryIdx != -1 {
+			if i >= lastSummaryIdx {
+				activeMessages = append(activeMessages, msg)
+			}
+		} else if msg.Role != message.Summary {
+			activeMessages = append(activeMessages, msg)
+		}
+	}
+
+	// 2. Check if active context fits
 	count, err := input.Counter.CountTokens(ctx, tokens.CountOptions{
-		Messages:     input.Messages,
+		Messages:     activeMessages,
 		SystemPrompt: input.SystemPrompt,
 		Tools:        input.Tools,
 	})
@@ -46,42 +69,49 @@ func (s *summarizeStrategy) Fit(
 
 	if count.TotalTokens <= input.MaxTokens {
 		return &tokens.StrategyResult{
-			Messages:      convertSummaryToUser(input.Messages),
+			Messages:      convertSummaryToUser(activeMessages),
 			SessionUpdate: nil,
 		}, nil
 	}
 
-	var systemMsgs, summaryMsgs, convMsgs []message.Message
-	for _, msg := range input.Messages {
+	// 3. Needs summary. Identify what to summarize within the active context.
+	var systemMsgs []message.Message
+	var lastSummary *message.Message
+	var convMsgs []message.Message
+
+	for i := range activeMessages {
+		msg := &activeMessages[i]
 		switch msg.Role {
 		case message.System:
-			systemMsgs = append(systemMsgs, msg)
+			systemMsgs = append(systemMsgs, *msg)
 		case message.Summary:
-			summaryMsgs = append(summaryMsgs, msg)
+			lastSummary = msg
 		default:
-			convMsgs = append(convMsgs, msg)
+			convMsgs = append(convMsgs, *msg)
 		}
 	}
 
 	splitPoint := len(convMsgs) - s.config.KeepRecent
 	if splitPoint <= 0 {
+		// Cannot summarize further without violating KeepRecent
 		return &tokens.StrategyResult{
-			Messages:      convertSummaryToUser(input.Messages),
+			Messages:      convertSummaryToUser(activeMessages),
 			SessionUpdate: nil,
 		}, nil
 	}
 
-	toSummarize := convMsgs[:splitPoint]
-	toKeep := convMsgs[splitPoint:]
-
-	if len(summaryMsgs) > 0 {
-		toSummarize = append(summaryMsgs, toSummarize...)
+	toSummarize := make([]message.Message, 0, splitPoint+1)
+	if lastSummary != nil {
+		toSummarize = append(toSummarize, *lastSummary)
 	}
+	toSummarize = append(toSummarize, convMsgs[:splitPoint]...)
+	toKeep := convMsgs[splitPoint:]
 
 	summary, err := s.generateSummary(ctx, toSummarize)
 	if err != nil {
+		// Fallback: return what we have if summary fails
 		return &tokens.StrategyResult{
-			Messages:      convertSummaryToUser(input.Messages),
+			Messages:      convertSummaryToUser(activeMessages),
 			SessionUpdate: nil,
 		}, nil
 	}
@@ -95,10 +125,15 @@ func (s *summarizeStrategy) Fit(
 	llmMessages = append(llmMessages, summaryMsgForLLM)
 	llmMessages = append(llmMessages, toKeep...)
 
+	sessionUpdateMsgs := make([]message.Message, 0, len(toKeep)+1)
+	sessionUpdateMsgs = append(sessionUpdateMsgs, summaryMsgForSession)
+	sessionUpdateMsgs = append(sessionUpdateMsgs, toKeep...)
+
 	return &tokens.StrategyResult{
 		Messages: llmMessages,
 		SessionUpdate: &tokens.SessionUpdate{
-			AddMessages: []message.Message{summaryMsgForSession},
+			PopCount:    len(toKeep),
+			AddMessages: sessionUpdateMsgs,
 		},
 	}, nil
 }


### PR DESCRIPTION
Tackling a little less in one batch. Enabled proper compaction without breaking change to the API.

Correct context compression continually re-compressing after reaching the token limit
After a summary was written to the session, subsequent turns would re-evaluate
the full message history instead of only the active context since the last
summary, causing the token limit to be exceeded again and triggering another
session_and_store_summarization_remediation.md) won't be included.

Key changes include:

**Agent Session Persistence and Context Strategy Improvements:**

* Refactored the `Agent`'s `buildMessages` and `buildContinueMessages` methods to apply context strategy results correctly, handling `PopCount` and `AddMessages` to update the session store. This ensures that messages are popped and added in alignment with the strategy's logical view, and prevents duplicate or missing user messages in the session. 
* Added clarifying comments and logic to handle the edge case where the user's message is included or excluded in the strategy's updates, ensuring correct session persistence.
* Improved documentation of the `SessionUpdate` struct, explaining the semantics of `PopCount` and `AddMessages`.

**Summarization Strategy Logic:**

* Updated the summarization strategy to identify the active context as system messages plus all messages since the last summary, ensuring that only unsummarized conversation is considered for token counting and summarization triggers.

**Testing and Validation:**

* Added thorough tests covering session persistence with `PopCount` and summarization strategies, verifying correct message compaction, summary anchoring, and prevention of redundant summarization. These tests cover both in-memory and file-based session stores, as well as edge cases that previously led to bugs. 



