### PR TITLE
Fix/buildmessages pop identity

### DIFF
--- a/agent/messages.go
+++ b/agent/messages.go
@@ -133,11 +133,18 @@ func (a *Agent) buildMessages(
 		messages = append(messages, sysMsg)
 	}
 
-	// 1. Fully construct the logical state of the conversation (History + New Msg)
 	messages = append(messages, sessionMessages...)
 	messages = append(messages, userMsg)
 
-	// 2. Evaluate Strategy
+	if a.session != nil {
+		if err := a.session.AddMessages(
+			ctx,
+			[]message.Message{userMsg},
+		); err != nil {
+			return nil, err
+		}
+	}
+
 	if a.contextStrategy != nil {
 		counter, err := tokens.NewCounter()
 		if err != nil {
@@ -164,81 +171,27 @@ func (a *Agent) buildMessages(
 			return nil, fmt.Errorf("context strategy failed: %w", err)
 		}
 
-		// 3. Apply Persistence Updates
-		if a.session != nil {
-			if result.SessionUpdate != nil {
-				// The Strategy evaluated [History..., UserMsg].
-				// Its PopCount represents the number of messages to remove from that array.
-				// However, UserMsg is not physically in the Session Store yet.
-				// We must adjust the PopCount to determine how many physical session messages to pop.
-
-				popCount := result.SessionUpdate.PopCount
-				userMsgIncludedInKeep := false
-
-				if len(result.SessionUpdate.AddMessages) > 0 {
-					lastAdded := result.SessionUpdate.AddMessages[len(result.SessionUpdate.AddMessages)-1]
-					if lastAdded.CreatedAt == userMsg.CreatedAt &&
-						lastAdded.Role == userMsg.Role {
-						userMsgIncludedInKeep = true
-					}
+		if result.SessionUpdate != nil && a.session != nil {
+			for i := 0; i < result.SessionUpdate.PopCount; i++ {
+				if _, err := a.session.PopMessage(ctx); err != nil {
+					return nil, fmt.Errorf("failed to pop message: %w", err)
 				}
+			}
 
-				if userMsgIncludedInKeep {
-					// The strategy 'popped' UserMsg logically as part of PopCount,
-					// but since it's not in the DB, we shouldn't pop a DB row for it.
-					popCount--
-				}
-
-				for i := 0; i < popCount; i++ {
-					if _, err := a.session.PopMessage(ctx); err != nil {
-						return nil, fmt.Errorf("failed to pop message: %w", err)
-					}
-				}
-
-				if len(result.SessionUpdate.AddMessages) > 0 {
-					if err := a.session.AddMessages(
-						ctx,
-						result.SessionUpdate.AddMessages,
-					); err != nil {
-						return nil, fmt.Errorf(
-							"failed to save session update: %w",
-							err,
-						)
-					}
-				}
-
-				// If userMsg wasn't included in the strategy's update (e.g. truncated),
-				// we still need to persist it normally as the latest action.
-				// But wait, if it was included in AddMessages, userMsgIncludedInKeep is true, we don't save it again.
-				// If it wasn't, we DO save it.
-				if !userMsgIncludedInKeep {
-					if err := a.session.AddMessages(
-						ctx,
-						[]message.Message{userMsg},
-					); err != nil {
-						return nil, err
-					}
-				}
-
-			} else {
-				// No session update needed from strategy, just add the new user message.
+			if len(result.SessionUpdate.AddMessages) > 0 {
 				if err := a.session.AddMessages(
 					ctx,
-					[]message.Message{userMsg},
+					result.SessionUpdate.AddMessages,
 				); err != nil {
-					return nil, err
+					return nil, fmt.Errorf(
+						"failed to save session update: %w",
+						err,
+					)
 				}
 			}
 		}
 
 		messages = result.Messages
-	} else if a.session != nil {
-		if err := a.session.AddMessages(
-			ctx,
-			[]message.Message{userMsg},
-		); err != nil {
-			return nil, err
-		}
 	}
 
 	return messages, nil

--- a/agent/messages.go
+++ b/agent/messages.go
@@ -172,7 +172,7 @@ func (a *Agent) buildMessages(
 		}
 
 		if result.SessionUpdate != nil && a.session != nil {
-			for i := 0; i < result.SessionUpdate.PopCount; i++ {
+			for range result.SessionUpdate.PopCount {
 				if _, err := a.session.PopMessage(ctx); err != nil {
 					return nil, fmt.Errorf("failed to pop message: %w", err)
 				}
@@ -250,7 +250,7 @@ func (a *Agent) buildContinueMessages(
 		}
 
 		if result.SessionUpdate != nil && a.session != nil {
-			for i := 0; i < result.SessionUpdate.PopCount; i++ {
+			for range result.SessionUpdate.PopCount {
 				if _, err := a.session.PopMessage(ctx); err != nil {
 					return nil, fmt.Errorf("failed to pop message: %w", err)
 				}

--- a/tests/agent/persistence_test.go
+++ b/tests/agent/persistence_test.go
@@ -45,10 +45,11 @@ func TestAgent_PersistenceWithPopCount(t *testing.T) {
 	a := agent.New(newMockLLM(mockResponse{Content: "Mock response"}),
 		agent.WithSession("test-session", store),
 		agent.WithContextStrategy(&mockStrategy{
-			popCount: 1, // Remove "Msg 2"
+			popCount: 2,
 			addMessages: []message.Message{
 				message.NewSummaryMessage("Summary of 1 and Resp 1"),
 				message.NewUserMessage("Msg 2 re-anchored"),
+				message.NewUserMessage("Msg 3 re-anchored"),
 			},
 		}, 10000),
 	)
@@ -66,10 +67,10 @@ func TestAgent_PersistenceWithPopCount(t *testing.T) {
 	// Expected messages:
 	// 0: Msg 1
 	// 1: Resp 1
-	// (Msg 2 was popped)
+	// (Msg 2 and Msg 3 were popped)
 	// 2: Summary of 1 and Resp 1
 	// 3: Msg 2 re-anchored
-	// 4: Msg 3 (the current user message)
+	// 4: Msg 3 re-anchored
 	// 5: Mock response (from assistant)
 
 	if len(msgs) != 6 {
@@ -87,9 +88,9 @@ func TestAgent_PersistenceWithPopCount(t *testing.T) {
 				msgs[3].Content().Text,
 			)
 		}
-		if msgs[4].Content().Text != "Msg 3" {
+		if msgs[4].Content().Text != "Msg 3 re-anchored" {
 			t.Errorf(
-				"expected msg 4 to be 'Msg 3', got %s",
+				"expected msg 4 to be 'Msg 3 re-anchored', got %s",
 				msgs[4].Content().Text,
 			)
 		}

--- a/tests/agent/persistence_test.go
+++ b/tests/agent/persistence_test.go
@@ -16,7 +16,7 @@ type mockStrategy struct {
 }
 
 func (s *mockStrategy) Fit(
-	ctx context.Context,
+	_ context.Context,
 	input tokens.StrategyInput,
 ) (*tokens.StrategyResult, error) {
 	return &tokens.StrategyResult{

--- a/tests/agent/summarize_test.go
+++ b/tests/agent/summarize_test.go
@@ -37,14 +37,14 @@ func TestAgent_SummarizeStrategy(t *testing.T) {
 	store := session.MemoryStore()
 
 	// Create a strategy with a low "KeepRecent"
-	strat := summarize.Strategy(summarizerLLM, summarize.KeepRecent(1))
+	strategy := summarize.Strategy(summarizerLLM, summarize.KeepRecent(1))
 
 	a := agent.New(mockAgentLLM,
 		agent.WithSession("test-session", store),
 		agent.WithSystemPrompt("You are a test assistant."),
 		// Force summary by setting a very low limit.
 		// Token count for "Message 1" + system prompt + overhead will easily exceed 20.
-		agent.WithContextStrategy(strat, 20),
+		agent.WithContextStrategy(strategy, 20),
 	)
 
 	// 2. First turn.

--- a/tests/session/strategy_integration_test.go
+++ b/tests/session/strategy_integration_test.go
@@ -24,12 +24,12 @@ func runSummarizeStrategyTest(t *testing.T, store session.Store) {
 	const sessionID = "strategy-test"
 	summarizer := &bugMockSummarizer{}
 	// Keep only the most recent message so a summary triggers quickly.
-	strat := summarize.Strategy(summarizer, summarize.KeepRecent(1))
+	strategy := summarize.Strategy(summarizer, summarize.KeepRecent(1))
 
 	a := agent.New(
 		&mockAgentLLM{t: t},
 		agent.WithSession(sessionID, store),
-		agent.WithContextStrategy(strat, 100),
+		agent.WithContextStrategy(strategy, 100),
 	)
 
 	// Chat until the active context exceeds the limit and a summary is produced.
@@ -92,7 +92,7 @@ func runSummarizeStrategyTest(t *testing.T, store session.Store) {
 	reloaded := agent.New(
 		&mockAgentLLM{t: t},
 		agent.WithSession(sessionID, store),
-		agent.WithContextStrategy(strat, 100),
+		agent.WithContextStrategy(strategy, 100),
 	)
 	if _, err := reloaded.Chat(ctx, "Short follow-up"); err != nil {
 		t.Fatalf("follow-up chat failed: %v", err)

--- a/tests/session/summarize_bug_test.go
+++ b/tests/session/summarize_bug_test.go
@@ -22,9 +22,9 @@ type bugMockSummarizer struct {
 }
 
 func (m *bugMockSummarizer) SendMessages(
-	ctx context.Context,
+	_ context.Context,
 	msgs []message.Message,
-	tools []tool.BaseTool,
+	_ []tool.BaseTool,
 ) (*llm.Response, error) {
 	m.callCount++
 	m.lastMsgs = msgs
@@ -34,27 +34,27 @@ func (m *bugMockSummarizer) SendMessages(
 }
 
 func (m *bugMockSummarizer) SendMessagesWithStructuredOutput(
-	ctx context.Context,
-	msgs []message.Message,
-	tools []tool.BaseTool,
-	outputSchema *schema.StructuredOutputInfo,
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
+	_ *schema.StructuredOutputInfo,
 ) (*llm.Response, error) {
 	return nil, nil
 }
 
 func (m *bugMockSummarizer) StreamResponse(
-	ctx context.Context,
-	msgs []message.Message,
-	tools []tool.BaseTool,
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
 ) <-chan llm.Event {
 	return nil
 }
 
 func (m *bugMockSummarizer) StreamResponseWithStructuredOutput(
-	ctx context.Context,
-	msgs []message.Message,
-	tools []tool.BaseTool,
-	outputSchema *schema.StructuredOutputInfo,
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
+	_ *schema.StructuredOutputInfo,
 ) <-chan llm.Event {
 	return nil
 }
@@ -73,9 +73,9 @@ type mockAgentLLM struct {
 }
 
 func (m *mockAgentLLM) SendMessages(
-	ctx context.Context,
+	_ context.Context,
 	msgs []message.Message,
-	tools []tool.BaseTool,
+	_ []tool.BaseTool,
 ) (*llm.Response, error) {
 	m.t.Logf("--> mockAgentLLM called with %d messages", len(msgs))
 	return &llm.Response{
@@ -84,27 +84,27 @@ func (m *mockAgentLLM) SendMessages(
 }
 
 func (m *mockAgentLLM) SendMessagesWithStructuredOutput(
-	ctx context.Context,
-	msgs []message.Message,
-	tools []tool.BaseTool,
-	outputSchema *schema.StructuredOutputInfo,
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
+	_ *schema.StructuredOutputInfo,
 ) (*llm.Response, error) {
 	return nil, nil
 }
 
 func (m *mockAgentLLM) StreamResponse(
-	ctx context.Context,
-	msgs []message.Message,
-	tools []tool.BaseTool,
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
 ) <-chan llm.Event {
 	return nil
 }
 
 func (m *mockAgentLLM) StreamResponseWithStructuredOutput(
-	ctx context.Context,
-	msgs []message.Message,
-	tools []tool.BaseTool,
-	outputSchema *schema.StructuredOutputInfo,
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
+	_ *schema.StructuredOutputInfo,
 ) <-chan llm.Event {
 	return nil
 }
@@ -123,12 +123,12 @@ func TestSummarizeStrategy_ReproductionBug(t *testing.T) {
 
 	summarizer := &bugMockSummarizer{}
 	// Keep 1 most recent message pair.
-	strat := summarize.Strategy(summarizer, summarize.KeepRecent(1))
+	strategy := summarize.Strategy(summarizer, summarize.KeepRecent(1))
 
 	a := agent.New(
 		&mockAgentLLM{t: t},
 		agent.WithSession("bug-test2", store),
-		agent.WithContextStrategy(strat, 100),
+		agent.WithContextStrategy(strategy, 100),
 	)
 
 	// Chat until we trigger a summary

--- a/tokens/summarize/strategy.go
+++ b/tokens/summarize/strategy.go
@@ -46,13 +46,14 @@ func (s *summarizeStrategy) Fit(
 	}
 
 	for i, msg := range input.Messages {
-		if msg.Role == message.System {
+		switch {
+		case msg.Role == message.System:
 			activeMessages = append(activeMessages, msg)
-		} else if lastSummaryIdx != -1 {
+		case lastSummaryIdx != -1:
 			if i >= lastSummaryIdx {
 				activeMessages = append(activeMessages, msg)
 			}
-		} else if msg.Role != message.Summary {
+		case msg.Role != message.Summary:
 			activeMessages = append(activeMessages, msg)
 		}
 	}


### PR DESCRIPTION
This pull request refactors and simplifies the message persistence logic in the agent's context strategy, particularly how messages are added and removed from the session store. It also cleans up test code and improves the clarity of test cases. The most significant changes are in how session updates are applied after a context strategy is evaluated, ensuring message persistence is more straightforward and less error-prone.