### PR TITLE
chore: cascade tokens@v0.2.0 to agent and tokens/summarize

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/joakimcarlsson/ai/message v0.1.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0
 	github.com/joakimcarlsson/ai/session v0.1.0
-	github.com/joakimcarlsson/ai/tokens v0.1.0
+	github.com/joakimcarlsson/ai/tokens v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.1
 	github.com/joakimcarlsson/ai/tracing v0.1.0
 	github.com/joakimcarlsson/ai/types v0.1.0

--- a/tokens/summarize/go.mod
+++ b/tokens/summarize/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/tokens v0.1.0
+	github.com/joakimcarlsson/ai/tokens v0.2.0
 )
 
 require (


### PR DESCRIPTION
`tokens@v0.2.0` adds `SessionUpdate.PopCount` (#198). `tokens/summarize` emits it and `agent` consumes it (pops `PopCount` messages before applying `AddMessages`), so both **must** `require tokens@v0.2.0` — otherwise a consumer resolving the old `tokens` floor via MVS hits a compile error.

- `agent`: `require tokens v0.1.0 → v0.2.0`
- `tokens/summarize`: `require tokens v0.1.0 → v0.2.0`

No code changes; both build clean with `GOWORK=off go build ./...`.

Follow-up after merge: tag `agent v0.3.2`, `tokens/summarize v0.1.2`, and the independent `memory/sqlite v0.1.1` (#197).