### PR TITLE
fix(voice): honor SessionUpdate.PopCount in context strategy

### DIFF
--- a/voice/context_strategy_test.go
+++ b/voice/context_strategy_test.go
@@ -205,6 +205,79 @@ func TestContextStrategy_SessionUpdatePersisted(t *testing.T) {
 	}
 }
 
+// applySessionUpdate honors SessionUpdate.PopCount: messages already persisted
+// to the session store are popped (so the next flush does not duplicate the
+// retained tail) and sessionPersisted is rewound to match. Mirrors the agent
+// buildMessages fix (#199).
+func TestApplySessionUpdate_PopCountRewindsStore(t *testing.T) {
+	ctx := context.Background()
+	store := session.MemoryStore()
+	sess, err := store.Create(ctx, "sess-pop")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	u1 := message.NewUserMessage("u1")
+	a1 := message.NewMessage(
+		message.Assistant,
+		[]message.ContentPart{message.TextContent{Text: "a1"}},
+	)
+	u2 := message.NewUserMessage("u2")
+	if err := sess.AddMessages(ctx, []message.Message{u1, a1, u2}); err != nil {
+		t.Fatalf("seed messages: %v", err)
+	}
+
+	v := &Agent{session: sess}
+	history := []message.Message{u1, a1, u2}
+	sessionPersisted := len(history)
+
+	summary := message.NewMessage(
+		message.Summary,
+		[]message.ContentPart{message.TextContent{Text: "summary"}},
+	)
+	update := &tokens.SessionUpdate{
+		PopCount:    2,
+		AddMessages: []message.Message{summary, u2},
+	}
+
+	if err := applySessionUpdate(
+		ctx, v, &history, &sessionPersisted, update,
+	); err != nil {
+		t.Fatalf("applySessionUpdate: %v", err)
+	}
+
+	if sessionPersisted != 1 {
+		t.Fatalf("expected sessionPersisted rewound to 1, got %d", sessionPersisted)
+	}
+	if stored, _ := sess.GetMessages(ctx, nil); len(stored) != 1 {
+		t.Fatalf("expected 1 message left in store after pop, got %d", len(stored))
+	}
+	if len(history) != 3 || history[1].Role != message.Summary {
+		t.Fatalf("expected history [u1, summary, u2], got %+v", history)
+	}
+
+	if err := sess.AddMessages(ctx, history[sessionPersisted:]); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	final, _ := sess.GetMessages(ctx, nil)
+	if len(final) != 3 {
+		t.Fatalf(
+			"expected 3 messages after flush (no duplication), got %d: %+v",
+			len(final),
+			final,
+		)
+	}
+	summaries := 0
+	for _, m := range final {
+		if m.Role == message.Summary {
+			summaries++
+		}
+	}
+	if summaries != 1 {
+		t.Fatalf("expected exactly 1 summary after flush, got %d", summaries)
+	}
+}
+
 // When no strategy is configured, history is passed through to the LLM
 // untouched (regression check for the no-op path).
 func TestContextStrategy_NoStrategyPassesThrough(t *testing.T) {

--- a/voice/go.mod
+++ b/voice/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/joakimcarlsson/ai/schema v0.1.0
 	github.com/joakimcarlsson/ai/session v0.1.0
 	github.com/joakimcarlsson/ai/stt v0.1.0
-	github.com/joakimcarlsson/ai/tokens v0.1.0
+	github.com/joakimcarlsson/ai/tokens v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.1
 	github.com/joakimcarlsson/ai/tts v0.1.0
 	github.com/joakimcarlsson/ai/types v0.1.0

--- a/voice/pipeline.go
+++ b/voice/pipeline.go
@@ -602,7 +602,7 @@ func applySessionUpdate(
 	if update.PopCount > 0 {
 		newLen := max(len(*history)-update.PopCount, 0)
 		if v.session != nil && newLen < *sessionPersisted {
-			for i := 0; i < *sessionPersisted-newLen; i++ {
+			for range *sessionPersisted - newLen {
 				if _, err := v.session.PopMessage(ctx); err != nil {
 					return fmt.Errorf("pop session message: %w", err)
 				}

--- a/voice/pipeline.go
+++ b/voice/pipeline.go
@@ -26,6 +26,7 @@ func runAssistantTurn(
 	ctx context.Context,
 	v *Agent,
 	history *[]message.Message,
+	sessionPersisted *int,
 	emit func(Event),
 	ttsAudio chan<- []byte,
 	state *turnState,
@@ -37,6 +38,7 @@ func runAssistantTurn(
 			ctx,
 			active,
 			history,
+			sessionPersisted,
 			emit,
 			ttsAudio,
 			state,
@@ -95,13 +97,14 @@ func streamLLMAndSpeak(
 	ctx context.Context,
 	v *Agent,
 	history *[]message.Message,
+	sessionPersisted *int,
 	emit func(Event),
 	ttsAudio chan<- []byte,
 	state *turnState,
 ) (string, []message.ToolCall, error) {
 	stp, supportsStreaming := v.tts.(tts.StreamingTextProvider)
 
-	llmMessages, err := applyContextStrategy(ctx, v, history)
+	llmMessages, err := applyContextStrategy(ctx, v, history, sessionPersisted)
 	if err != nil {
 		return "", nil, err
 	}
@@ -546,6 +549,7 @@ func applyContextStrategy(
 	ctx context.Context,
 	v *Agent,
 	history *[]message.Message,
+	sessionPersisted *int,
 ) ([]message.Message, error) {
 	if v.contextStrategy == nil {
 		return *history, nil
@@ -571,11 +575,46 @@ func applyContextStrategy(
 	if result == nil {
 		return *history, nil
 	}
-	if result.SessionUpdate != nil &&
-		len(result.SessionUpdate.AddMessages) > 0 {
-		*history = append(*history, result.SessionUpdate.AddMessages...)
+	if result.SessionUpdate != nil {
+		if err := applySessionUpdate(
+			ctx, v, history, sessionPersisted, result.SessionUpdate,
+		); err != nil {
+			return nil, err
+		}
 	}
 	return result.Messages, nil
+}
+
+// applySessionUpdate folds a strategy SessionUpdate into the live history and
+// the persisted session. PopCount messages are dropped from the end of the
+// in-flight history; any of those already written to the session store are
+// popped from it as well and sessionPersisted is rewound to match, so the
+// store does not retain the messages the summary replaces. AddMessages (the
+// summary plus the retained tail) are then appended and persisted on the next
+// turn-boundary flush. Mirrors the agent buildMessages handling (#199).
+func applySessionUpdate(
+	ctx context.Context,
+	v *Agent,
+	history *[]message.Message,
+	sessionPersisted *int,
+	update *tokens.SessionUpdate,
+) error {
+	if update.PopCount > 0 {
+		newLen := max(len(*history)-update.PopCount, 0)
+		if v.session != nil && newLen < *sessionPersisted {
+			for i := 0; i < *sessionPersisted-newLen; i++ {
+				if _, err := v.session.PopMessage(ctx); err != nil {
+					return fmt.Errorf("pop session message: %w", err)
+				}
+			}
+			*sessionPersisted = newLen
+		}
+		*history = (*history)[:newLen]
+	}
+	if len(update.AddMessages) > 0 {
+		*history = append(*history, update.AddMessages...)
+	}
+	return nil
 }
 
 func resolveMaxTokens(v *Agent) int64 {

--- a/voice/runner.go
+++ b/voice/runner.go
@@ -237,6 +237,7 @@ func (c *Conversation) run(
 					turnCtx,
 					activeAgent,
 					&history,
+					&sessionPersisted,
 					emit,
 					ttsAudio,
 					state,


### PR DESCRIPTION
Follow-up to #199, which fixed `agent` but left `voice` with the same bug.

`voice/pipeline.go`'s `applyContextStrategy` appended `SessionUpdate.AddMessages` to history but **ignored `PopCount`**. With the `tokens v0.2.0` summarize contract (which now emits `PopCount` + `AddMessages = [summary, ...toKeep]`), the retained tail was duplicated in both the live history and the persisted session.

The fix pops `PopCount` messages from the end of history and rewinds the runner's `sessionPersisted` index, popping the already-persisted ones from the session store via `PopMessage`, before appending `AddMessages` — mirroring `agent.buildMessages` (#199). `PopCount`/`sessionPersisted` are threaded through `runAssistantTurn` → `streamLLMAndSpeak` → `applyContextStrategy`.

- `require tokens@v0.2.0` (the module now references `SessionUpdate.PopCount`)
- Regression test `TestApplySessionUpdate_PopCountRewindsStore` asserts the store ends up de-duplicated after the next flush.

Note: a voice handoff that swaps to an agent with a *different* session is a pre-existing edge case not addressed here (the runner persists to the original conversation session).

Follow-up after merge: tag `voice` (minor — `require` bump for the fix) and cut a release.