### PR TITLE
chore(berget): pin new modules to published deps

### DIFF
--- a/embeddings/berget/go.mod
+++ b/embeddings/berget/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.1.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect
 	github.com/openai/openai-go v1.12.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/llm/berget/go.mod
+++ b/llm/berget/go.mod
@@ -4,7 +4,12 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.4.0
-	github.com/joakimcarlsson/ai/llm/openai v0.4.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.2
+	github.com/joakimcarlsson/ai/message v0.1.0
+	github.com/joakimcarlsson/ai/model v0.4.0
+	github.com/joakimcarlsson/ai/schema v0.1.0
+	github.com/joakimcarlsson/ai/tool v0.1.1
+	github.com/joakimcarlsson/ai/types v0.1.0
 )
 
 require (
@@ -15,12 +20,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.0 // indirect
-	github.com/joakimcarlsson/ai/types v0.1.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/openai/openai-go/v3 v3.41.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/rerankers/berget/go.mod
+++ b/rerankers/berget/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/rerankers/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.4.0
 	github.com/joakimcarlsson/ai/rerankers v0.1.0
 )
 

--- a/stt/berget/go.mod
+++ b/stt/berget/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/stt/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.1.0
+	github.com/joakimcarlsson/ai/model v0.4.0
 	github.com/joakimcarlsson/ai/stt v0.1.0
 )
 


### PR DESCRIPTION
The berget provider modules (added in #204) were scaffolded against `model v0.1.0`, which predates the berget model constants introduced in `model v0.4.0`. A `go get llm/berget@latest` user would resolve `model v0.1.0` via MVS and not see `model.Berget*`.

- all 4 berget modules: `require model@v0.4.0` (const cascade)
- `llm/berget`: also `require llm/openai@v0.4.2` (conditional tool-params fix from #204)

go.mod-only; all four build clean with `GOWORK=off go build ./...` and lint 0 issues.

Follow-up after merge: tag `llm/berget`, `embeddings/berget`, `rerankers/berget`, `stt/berget` at `v0.1.0`.