### PR TITLE
feat(anthropic): add Claude Sonnet 5 and Fable 5 models

### DIFF
--- a/model/anthropic.go
+++ b/model/anthropic.go
@@ -18,6 +18,8 @@ const (
 	Claude46Sonnet ID = "claude-4.6-sonnet"
 	Claude47Opus   ID = "claude-4.7-opus"
 	Claude48Opus   ID = "claude-4.8-opus"
+	Claude5Sonnet  ID = "claude-5-sonnet"
+	Claude5Fable   ID = "claude-5-fable"
 )
 
 // AnthropicModels maps Anthropic model IDs to their configurations.
@@ -221,6 +223,36 @@ var AnthropicModels = map[ID]Model{
 		CostPer1MInCached:     6.25,
 		CostPer1MOutCached:    0.50,
 		CostPer1MOut:          25.0,
+		ContextWindow:         1000000,
+		DefaultMaxTokens:      128000,
+		CanReason:             true,
+		SupportsAttachments:   true,
+		SupportsStructuredOut: true,
+	},
+	Claude5Sonnet: {
+		ID:                    Claude5Sonnet,
+		Name:                  "Claude Sonnet 5",
+		Provider:              ProviderAnthropic,
+		APIModel:              "claude-sonnet-5",
+		CostPer1MIn:           3.0,
+		CostPer1MInCached:     3.75,
+		CostPer1MOutCached:    0.30,
+		CostPer1MOut:          15.0,
+		ContextWindow:         1000000,
+		DefaultMaxTokens:      128000,
+		CanReason:             true,
+		SupportsAttachments:   true,
+		SupportsStructuredOut: true,
+	},
+	Claude5Fable: {
+		ID:                    Claude5Fable,
+		Name:                  "Claude Fable 5",
+		Provider:              ProviderAnthropic,
+		APIModel:              "claude-fable-5",
+		CostPer1MIn:           10.0,
+		CostPer1MInCached:     12.5,
+		CostPer1MOutCached:    1.0,
+		CostPer1MOut:          50.0,
 		ContextWindow:         1000000,
 		DefaultMaxTokens:      128000,
 		CanReason:             true,

--- a/model/openrouter.go
+++ b/model/openrouter.go
@@ -33,6 +33,7 @@ const (
 	OpenRouterClaude46Sonnet    ID = "openrouter.claude-4.6-sonnet"
 	OpenRouterClaude47Opus      ID = "openrouter.claude-4.7-opus"
 	OpenRouterClaude48Opus      ID = "openrouter.claude-4.8-opus"
+	OpenRouterClaude5Sonnet     ID = "openrouter.claude-5-sonnet"
 	OpenRouterGPT52Codex        ID = "openrouter.gpt-5.2-codex"
 	OpenRouterMistralLarge3     ID = "openrouter.mistral-large-3"
 	OpenRouterMistralMedium3    ID = "openrouter.mistral-medium-3"
@@ -457,6 +458,20 @@ var OpenRouterModels = map[ID]Model{
 		DefaultMaxTokens:      AnthropicModels[Claude46Sonnet].DefaultMaxTokens,
 		CanReason:             AnthropicModels[Claude46Sonnet].CanReason,
 		SupportsStructuredOut: AnthropicModels[Claude46Sonnet].SupportsStructuredOut,
+	},
+	OpenRouterClaude5Sonnet: {
+		ID:                    OpenRouterClaude5Sonnet,
+		Name:                  "OpenRouter – Claude Sonnet 5",
+		Provider:              ProviderOpenRouter,
+		APIModel:              "anthropic/claude-sonnet-5",
+		CostPer1MIn:           AnthropicModels[Claude5Sonnet].CostPer1MIn,
+		CostPer1MInCached:     AnthropicModels[Claude5Sonnet].CostPer1MInCached,
+		CostPer1MOut:          AnthropicModels[Claude5Sonnet].CostPer1MOut,
+		CostPer1MOutCached:    AnthropicModels[Claude5Sonnet].CostPer1MOutCached,
+		ContextWindow:         AnthropicModels[Claude5Sonnet].ContextWindow,
+		DefaultMaxTokens:      AnthropicModels[Claude5Sonnet].DefaultMaxTokens,
+		CanReason:             AnthropicModels[Claude5Sonnet].CanReason,
+		SupportsStructuredOut: AnthropicModels[Claude5Sonnet].SupportsStructuredOut,
 	},
 	OpenRouterGPT52Codex: {
 		ID:                    OpenRouterGPT52Codex,


### PR DESCRIPTION
## Summary

Adds two current-generation Anthropic models to the registry:

- **Claude Sonnet 5** (`claude-sonnet-5`) — 1M context, 128K max output, adaptive thinking, structured output. Standard pricing \$3/\$15 per MTok.
- **Claude Fable 5** (`claude-fable-5`) — 1M context, 128K max output, adaptive thinking, structured output. Pricing \$10/\$50 per MTok.
- **OpenRouter mirror** for Sonnet 5 (`anthropic/claude-sonnet-5`).

## Notes / decisions

- Used Sonnet 5 **standard** pricing (\$3/\$15), not the introductory \$2/\$10 that expires 2026-08-31 — the registry has no notion of time-limited pricing.
- Both models use adaptive thinking, so they are intentionally **not** added to `usesLegacyExtendedThinking` in `llm/anthropic/anthropic.go`.
- **Mythos 5** omitted — it's limited-availability (Project Glasswing), consistent with how the registry skips preview models.
- No OpenRouter Fable entry — there's no existing Fable mirror and I didn't want to invent an OpenRouter slug.

## Testing

- `go build ./...` and `go vet ./...` pass (via `GOWORK=off`; the `go.work` toolchain-version errors are pre-existing and unrelated).
- `gofmt` clean.