### PR TITLE
chore: cascade model@v0.5.0 to anthropic/openrouter consumers

### DIFF
--- a/batch/anthropic/go.mod
+++ b/batch/anthropic/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/joakimcarlsson/ai/batch v0.1.0
 	github.com/joakimcarlsson/ai/llm v0.1.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.3.0
+	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/tool v0.1.1
 )
 

--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
 	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.3.0
+	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.1.0
 	github.com/joakimcarlsson/ai/tool v0.1.1
 	github.com/joakimcarlsson/ai/types v0.1.0

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/joakimcarlsson/ai/llm v0.4.0
 	github.com/joakimcarlsson/ai/llm/openai v0.4.0
 	github.com/joakimcarlsson/ai/message v0.1.0
-	github.com/joakimcarlsson/ai/model v0.3.0
+	github.com/joakimcarlsson/ai/model v0.5.0
 )
 
 require (


### PR DESCRIPTION
Follow-up to #206 (Claude Sonnet 5 + Fable 5 added to `model`, tagged `model/v0.5.0`).

Bumps the `model` require to `v0.5.0` in the consumer modules a user `go get`s to reach the new constants, per the README §3 cascade rule (scoped to the affected providers, not umbrella/unrelated modules):

- `llm/anthropic` (`v0.3.0 → v0.5.0`)
- `llm/openrouter` (`v0.3.0 → v0.5.0`)
- `batch/anthropic` (`v0.3.0 → v0.5.0`)

Each was `go mod tidy`'d and `go build ./...` / `go vet ./...` pass. Only the `model` require line changed. After merge, each module gets a patch tag (`llm/anthropic/v0.3.2`, `llm/openrouter/v0.2.6`, `batch/anthropic/v0.1.4`) and the dated release is cut.