### PR TITLE
chore: cascade fim@v0.2.0 and rerankers@v0.2.0 to their providers

### DIFF
--- a/fim/deepseek/go.mod
+++ b/fim/deepseek/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/fim/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/fim v0.1.1
+	github.com/joakimcarlsson/ai/fim v0.2.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/fim/mistral/go.mod
+++ b/fim/mistral/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/fim/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/fim v0.1.1
+	github.com/joakimcarlsson/ai/fim v0.2.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/rerankers/berget/go.mod
+++ b/rerankers/berget/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/rerankers v0.1.1
+	github.com/joakimcarlsson/ai/rerankers v0.2.0
 )
 
 require (

--- a/rerankers/cohere/go.mod
+++ b/rerankers/cohere/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/rerankers v0.1.1
+	github.com/joakimcarlsson/ai/rerankers v0.2.0
 )
 
 require (

--- a/rerankers/voyage/go.mod
+++ b/rerankers/voyage/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/rerankers v0.1.1
+	github.com/joakimcarlsson/ai/rerankers v0.2.0
 )
 
 require (


### PR DESCRIPTION
The shared-transport refactor (#208) added `fim.Post`/`fim.StreamSSE`/`fim.StreamChunk` (→ `fim v0.2.0`) and `rerankers.PostJSON` (→ `rerankers v0.2.0`) and rewired the providers onto them — but the providers still pinned `fim v0.1.1` / `rerankers v0.1.1`, which lack those symbols. A `go get` consumer would fail to compile.

- `require fim@v0.2.0`: `fim/deepseek`, `fim/mistral`
- `require rerankers@v0.2.0`: `rerankers/cohere`, `rerankers/voyage`, `rerankers/berget`

go.mod-only; all five build clean with `GOWORK=off go build ./...`.