### PR TITLE
chore: full-fleet version sync + fim/rerankers transport cascade + sync-deps fix

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -3,12 +3,12 @@ module github.com/joakimcarlsson/ai/agent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/memory v0.2.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/memory v0.2.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0
-	github.com/joakimcarlsson/ai/session v0.1.0
-	github.com/joakimcarlsson/ai/tokens v0.2.1
+	github.com/joakimcarlsson/ai/session v0.1.1
+	github.com/joakimcarlsson/ai/tokens v0.2.2
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 	github.com/joakimcarlsson/ai/types v0.1.0
@@ -22,7 +22,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.2.2 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect

--- a/batch/anthropic/go.mod
+++ b/batch/anthropic/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
-	github.com/joakimcarlsson/ai/batch v0.1.2
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/batch v0.1.3
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
@@ -22,7 +22,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.2.2 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
 	github.com/joakimcarlsson/ai/types v0.1.0 // indirect

--- a/batch/concurrent/go.mod
+++ b/batch/concurrent/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/batch/concurrent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.2
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
-	github.com/joakimcarlsson/ai/llm v0.4.1
+	github.com/joakimcarlsson/ai/batch v0.1.3
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
 )
 
 require (
@@ -16,7 +16,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/batch/gemini/go.mod
+++ b/batch/gemini/go.mod
@@ -4,10 +4,10 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/batch v0.1.2
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/batch v0.1.3
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	google.golang.org/genai v1.61.0

--- a/batch/go.mod
+++ b/batch/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/batch
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 

--- a/batch/openai/go.mod
+++ b/batch/openai/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/batch/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.2
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/batch v0.1.3
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/openai/openai-go/v3 v3.41.0

--- a/embeddings/bedrock/go.mod
+++ b/embeddings/bedrock/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/embeddings/berget/go.mod
+++ b/embeddings/berget/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
-	github.com/joakimcarlsson/ai/embeddings/openai v0.1.2
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
+	github.com/joakimcarlsson/ai/embeddings/openai v0.1.3
 )
 
 require (

--- a/embeddings/cohere/go.mod
+++ b/embeddings/cohere/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/cohere
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/embeddings/gemini/go.mod
+++ b/embeddings/gemini/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/gemini
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 	google.golang.org/genai v1.61.0
 )

--- a/embeddings/mistral/go.mod
+++ b/embeddings/mistral/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/embeddings/openai/go.mod
+++ b/embeddings/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/openai/openai-go/v3 v3.41.0
 )

--- a/embeddings/voyage/go.mod
+++ b/embeddings/voyage/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/voyage
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/fim/deepseek/go.mod
+++ b/fim/deepseek/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/fim/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/fim v0.1.1
+	github.com/joakimcarlsson/ai/fim v0.2.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/fim/mistral/go.mod
+++ b/fim/mistral/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/fim/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/fim v0.1.1
+	github.com/joakimcarlsson/ai/fim v0.2.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/image/gemini/go.mod
+++ b/image/gemini/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/image/gemini
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/image v0.1.1
+	github.com/joakimcarlsson/ai/image v0.1.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 	google.golang.org/genai v1.61.0
 )

--- a/image/openai/go.mod
+++ b/image/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/image/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/image v0.1.1
+	github.com/joakimcarlsson/ai/image v0.1.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/openai/openai-go/v3 v3.41.0
 )

--- a/image/xai/go.mod
+++ b/image/xai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/image/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/image v0.1.1
+	github.com/joakimcarlsson/ai/image v0.1.2
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/openai/openai-go/v3 v3.41.0
 )

--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/azure/go.mod
+++ b/llm/azure/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/openai/openai-go/v3 v3.41.0
 )

--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/bedrock
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/anthropic v0.3.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/anthropic v0.3.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/berget/go.mod
+++ b/llm/berget/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/cerebras
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/fireworks
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -4,8 +4,8 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/go.mod
+++ b/llm/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/llm
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/groq/go.mod
+++ b/llm/groq/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/groq
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/ollama
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/openrouter
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/perplexity
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 )
 

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/together
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/vertexai
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/gemini v0.3.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/gemini v0.3.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	google.golang.org/genai v1.61.0
 )

--- a/llm/xai/go.mod
+++ b/llm/xai/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 

--- a/memory/pgvector/go.mod
+++ b/memory/pgvector/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.1
-	github.com/joakimcarlsson/ai/memory v0.2.2
+	github.com/joakimcarlsson/ai/embeddings v0.2.2
+	github.com/joakimcarlsson/ai/memory v0.2.3
 	github.com/lib/pq v1.12.3
 )
 
@@ -16,8 +16,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/llm v0.4.1 // indirect
-	github.com/joakimcarlsson/ai/message v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/llm v0.4.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/memory/postgres/go.mod
+++ b/memory/postgres/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/message v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.0
+	github.com/joakimcarlsson/ai/message v0.3.0
+	github.com/joakimcarlsson/ai/session v0.1.1
 	github.com/lib/pq v1.12.3
 )
 

--- a/memory/sqlite/go.mod
+++ b/memory/sqlite/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/memory/sqlite
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.0
+	github.com/joakimcarlsson/ai/message v0.3.0
+	github.com/joakimcarlsson/ai/session v0.1.1
 )
 
 require github.com/joakimcarlsson/ai/model v0.5.0 // indirect

--- a/rerankers/berget/go.mod
+++ b/rerankers/berget/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/rerankers v0.1.1
+	github.com/joakimcarlsson/ai/rerankers v0.2.0
 )
 
 require (

--- a/rerankers/cohere/go.mod
+++ b/rerankers/cohere/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/rerankers v0.1.1
+	github.com/joakimcarlsson/ai/rerankers v0.2.0
 )
 
 require (

--- a/rerankers/voyage/go.mod
+++ b/rerankers/voyage/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/rerankers v0.1.1
+	github.com/joakimcarlsson/ai/rerankers v0.2.0
 )
 
 require (

--- a/scripts/sync-deps.sh
+++ b/scripts/sync-deps.sh
@@ -74,6 +74,7 @@ while IFS= read -r mod; do
 		want="$(latest_version "$dep_dir")"
 		[[ -z "$want" ]] && continue      # dep not tagged yet; nothing to sync to
 		[[ "$have" == "$want" ]] && continue
+		[[ "$(printf '%s\n%s\n' "$have" "$want" | sort -V | tail -n1)" == "$have" ]] && continue
 		drift=$((drift + 1))
 		echo "DRIFT  $mod: $path  $have -> $want"
 		if [[ "$check_only" == false ]]; then

--- a/session/go.mod
+++ b/session/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/session
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/message v0.2.0
+require github.com/joakimcarlsson/ai/message v0.3.0
 
 require github.com/joakimcarlsson/ai/model v0.5.0 // indirect
 

--- a/stt/assemblyai/go.mod
+++ b/stt/assemblyai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
 )
 
 require (

--- a/stt/azure/go.mod
+++ b/stt/azure/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
 )
 
 require (

--- a/stt/berget/go.mod
+++ b/stt/berget/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
 )
 
 require (

--- a/stt/deepgram/go.mod
+++ b/stt/deepgram/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
 )
 
 require (

--- a/stt/elevenlabs/go.mod
+++ b/stt/elevenlabs/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
 )
 
 require (

--- a/stt/google/go.mod
+++ b/stt/google/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
 )
 
 require (

--- a/stt/openai/go.mod
+++ b/stt/openai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/agent v0.3.3
-	github.com/joakimcarlsson/ai/fim v0.1.1
+	github.com/joakimcarlsson/ai/fim v0.2.0
 	github.com/joakimcarlsson/ai/llm v0.4.1
 	github.com/joakimcarlsson/ai/memory v0.2.2
 	github.com/joakimcarlsson/ai/message v0.2.0

--- a/tokens/go.mod
+++ b/tokens/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/tokens
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 

--- a/tokens/sliding/go.mod
+++ b/tokens/sliding/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tokens/sliding
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.2.0
-	github.com/joakimcarlsson/ai/tokens v0.2.1
+	github.com/joakimcarlsson/ai/message v0.3.0
+	github.com/joakimcarlsson/ai/tokens v0.2.2
 )
 
 require (

--- a/tokens/summarize/go.mod
+++ b/tokens/summarize/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/tokens/summarize
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/message v0.2.0
-	github.com/joakimcarlsson/ai/tokens v0.2.1
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/message v0.3.0
+	github.com/joakimcarlsson/ai/tokens v0.2.2
 )
 
 require (

--- a/tokens/truncate/go.mod
+++ b/tokens/truncate/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tokens/truncate
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.2.0
-	github.com/joakimcarlsson/ai/tokens v0.2.1
+	github.com/joakimcarlsson/ai/message v0.3.0
+	github.com/joakimcarlsson/ai/tokens v0.2.2
 )
 
 require (

--- a/tts/azure/go.mod
+++ b/tts/azure/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/tts v0.2.1
+	github.com/joakimcarlsson/ai/tts v0.2.2
 )
 
 require (

--- a/tts/deepgram/go.mod
+++ b/tts/deepgram/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/tts v0.2.1
+	github.com/joakimcarlsson/ai/tts v0.2.2
 )
 
 require (

--- a/tts/elevenlabs/go.mod
+++ b/tts/elevenlabs/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/tts v0.2.1
+	github.com/joakimcarlsson/ai/tts v0.2.2
 )
 
 require (

--- a/tts/google/go.mod
+++ b/tts/google/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/tts v0.2.1
+	github.com/joakimcarlsson/ai/tts v0.2.2
 )
 
 require (

--- a/tts/openai/go.mod
+++ b/tts/openai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/model v0.5.0
-	github.com/joakimcarlsson/ai/tts v0.2.1
+	github.com/joakimcarlsson/ai/tts v0.2.2
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,16 +3,16 @@ module github.com/joakimcarlsson/ai/voice
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.1
-	github.com/joakimcarlsson/ai/memory v0.2.2
-	github.com/joakimcarlsson/ai/message v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.4.2
+	github.com/joakimcarlsson/ai/memory v0.2.3
+	github.com/joakimcarlsson/ai/message v0.3.0
 	github.com/joakimcarlsson/ai/model v0.5.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.0
-	github.com/joakimcarlsson/ai/stt v0.2.1
-	github.com/joakimcarlsson/ai/tokens v0.2.1
+	github.com/joakimcarlsson/ai/session v0.1.1
+	github.com/joakimcarlsson/ai/stt v0.2.2
+	github.com/joakimcarlsson/ai/tokens v0.2.2
 	github.com/joakimcarlsson/ai/tool v0.1.2
-	github.com/joakimcarlsson/ai/tts v0.2.1
+	github.com/joakimcarlsson/ai/tts v0.2.2
 	github.com/joakimcarlsson/ai/types v0.1.0
 	golang.org/x/sync v0.21.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.2.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect


### PR DESCRIPTION
Full-fleet release prep. Three commits:

1. **fim/rerankers transport cascade** (`cc5f7ea`) — providers require `fim@v0.2.0` / `rerankers@v0.2.0` (they use the new `Post`/`StreamSSE`/`PostJSON`).
2. **sync-deps fix** (`f72712b`) — `sync-deps.sh --check` no longer flags a require that *leads* the latest tag (the mid-release case), so a full sync can land before the tags exist.
3. **Full intra-repo require sync** (`d1b5aa7`) — every module's internal `require` lines rewritten to this release's target versions, so each new tag pins its siblings at their new tags rather than trailing ones (this is what #207/#209 set up but never tagged).

Verification: `sync-deps.sh --check` green; **all 74 modules build clean** in workspace mode; no self-requires. CI builds each module against `go.work`, so requires on the about-to-be-published versions resolve locally.

After merge: tag all changed modules at their target versions (message `v0.3.0` minor — breaking dead-code removal; the rest patch), warm, umbrella release.