### PR TITLE
Configureation and Propegation of Reasoning content in OpenAI compatible providers

### DIFF
--- a/agent/chat.go
+++ b/agent/chat.go
@@ -382,10 +382,13 @@ func (a *Agent) runLoop(
 				if resp.Content != "" {
 					assistantMsg.AppendContent(resp.Content)
 				}
+				if resp.Reasoning != "" {
+					assistantMsg.AppendReasoningContent(resp.Reasoning)
+				}
 				if len(resp.ToolCalls) > 0 && !activeAgent.autoExecute {
 					assistantMsg.AppendToolCalls(resp.ToolCalls)
 				}
-				if resp.Content != "" ||
+				if resp.Content != "" || resp.Reasoning != "" ||
 					len(resp.ToolCalls) > 0 && !activeAgent.autoExecute {
 					if err := activeAgent.session.AddMessages(
 						ctx,
@@ -402,6 +405,7 @@ func (a *Agent) runLoop(
 
 			chatResp := &ChatResponse{
 				Content:            resp.Content,
+				Reasoning:          resp.Reasoning,
 				ToolCalls:          resp.ToolCalls,
 				Usage:              totalUsage,
 				FinishReason:       resp.FinishReason,
@@ -422,6 +426,9 @@ func (a *Agent) runLoop(
 		assistantMsg.Model = activeAgent.llm.Model().ID
 		if resp.Content != "" {
 			assistantMsg.AppendContent(resp.Content)
+		}
+		if resp.Reasoning != "" {
+			assistantMsg.AppendReasoningContent(resp.Reasoning)
 		}
 		assistantMsg.AppendToolCalls(resp.ToolCalls)
 		messages = append(messages, assistantMsg)

--- a/agent/response.go
+++ b/agent/response.go
@@ -15,6 +15,8 @@ import (
 type ChatResponse struct {
 	// Content is the final text response from the agent.
 	Content string
+	// Reasoning is the accumulated reasoning/thinking content.
+	Reasoning string
 	// ToolCalls contains any pending tool calls from the final LLM response.
 	ToolCalls []message.ToolCall
 	// ToolResults contains the results of all tool executions during the conversation.

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -386,6 +386,7 @@ func (a *Agent) runLoopStream(
 
 	for {
 		var fullContent string
+		var fullReasoning string
 		var toolCalls []message.ToolCall
 		var finalResponse *llm.Response
 		seenToolStarts := make(map[string]bool)
@@ -423,6 +424,7 @@ func (a *Agent) runLoopStream(
 				fullContent += event.Content
 				eventChan <- ChatEvent{Type: types.EventContentDelta, Content: event.Content}
 			case types.EventThinkingDelta:
+				fullReasoning += event.Thinking
 				eventChan <- ChatEvent{Type: types.EventThinkingDelta, Thinking: event.Thinking}
 			case types.EventToolUseStart,
 				types.EventToolUseDelta,
@@ -496,12 +498,15 @@ func (a *Agent) runLoopStream(
 				if mrResult.Action == HookModify && mrResult.Response != nil {
 					finalResponse = mrResult.Response
 					toolCalls = finalResponse.ToolCalls
+					fullContent = finalResponse.Content
+					fullReasoning = finalResponse.Reasoning
 				}
 			}
 		}
 
 		if streamRecovered && finalResponse != nil {
 			fullContent = finalResponse.Content
+			fullReasoning = finalResponse.Reasoning
 		}
 
 		if len(toolCalls) == 0 || !activeAgent.autoExecute ||
@@ -512,10 +517,13 @@ func (a *Agent) runLoopStream(
 				if fullContent != "" {
 					assistantMsg.AppendContent(fullContent)
 				}
+				if fullReasoning != "" {
+					assistantMsg.AppendReasoningContent(fullReasoning)
+				}
 				if len(toolCalls) > 0 && !activeAgent.autoExecute {
 					assistantMsg.AppendToolCalls(toolCalls)
 				}
-				if fullContent != "" ||
+				if fullContent != "" || fullReasoning != "" ||
 					len(toolCalls) > 0 && !activeAgent.autoExecute {
 					_ = activeAgent.session.AddMessages(
 						ctx,
@@ -537,6 +545,7 @@ func (a *Agent) runLoopStream(
 
 			chatResp := &ChatResponse{
 				Content:            fullContent,
+				Reasoning:          fullReasoning,
 				ToolCalls:          toolCalls,
 				Usage:              totalUsage,
 				FinishReason:       finishReason,
@@ -558,6 +567,9 @@ func (a *Agent) runLoopStream(
 		assistantMsg.Model = activeAgent.llm.Model().ID
 		if fullContent != "" {
 			assistantMsg.AppendContent(fullContent)
+		}
+		if fullReasoning != "" {
+			assistantMsg.AppendReasoningContent(fullReasoning)
 		}
 		assistantMsg.AppendToolCalls(toolCalls)
 		messages = append(messages, assistantMsg)

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -147,6 +147,7 @@ type Choice struct {
 // Response represents the complete response from an LLM provider.
 type Response struct {
 	Content                    string
+	Reasoning                  string
 	ToolCalls                  []message.ToolCall
 	Usage                      TokenUsage
 	FinishReason               message.FinishReason

--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -37,29 +37,30 @@ const (
 
 // Options configures the OpenAI LLM client.
 type Options struct {
-	apiKey            string
-	model             model.Model
-	maxTokens         int64
-	temperature       *float64
-	topP              *float64
-	topK              *int64
-	stopSequences     []string
-	timeout           *time.Duration
-	baseURL           string
-	disableCache      bool
-	reasoningEffort   *ReasoningEffort
-	extraHeaders      map[string]string
-	frequencyPenalty  *float64
-	presencePenalty   *float64
-	seed              *int64
-	parallelToolCalls *bool
-	toolChoice        *llm.ToolChoice
-	extraBodyFields   map[string]any
-	metadataFields    map[string]string
-	httpClient        *http.Client
-	logitBias         map[string]int
-	topLogprobs       *int
-	n                 *int64
+	apiKey                 string
+	model                  model.Model
+	maxTokens              int64
+	temperature            *float64
+	topP                   *float64
+	topK                   *int64
+	stopSequences          []string
+	timeout                *time.Duration
+	baseURL                string
+	disableCache           bool
+	reasoningEffort        *ReasoningEffort
+	extraHeaders           map[string]string
+	frequencyPenalty       *float64
+	presencePenalty        *float64
+	seed                   *int64
+	parallelToolCalls      *bool
+	toolChoice             *llm.ToolChoice
+	extraBodyFields        map[string]any
+	metadataFields         map[string]string
+	httpClient             *http.Client
+	logitBias              map[string]int
+	topLogprobs            *int
+	n                      *int64
+	reasoningContentReplay bool
 }
 
 // Option configures Options.
@@ -117,6 +118,11 @@ func WithBaseURL(
 	baseURL string,
 ) Option {
 	return func(o *Options) { o.baseURL = baseURL }
+}
+
+// WithReasoningContentReplay enables echoing previous reasoning content back in assistant messages.
+func WithReasoningContentReplay(enable bool) Option {
+	return func(o *Options) { o.reasoningContentReplay = enable }
 }
 
 // WithExtraHeaders adds custom HTTP headers to API requests.
@@ -393,6 +399,15 @@ func (c *Client) convertMessages(
 				}
 			}
 
+			if c.options.reasoningContentReplay {
+				rcs := msg.ReasoningContent()
+				if len(rcs) > 0 && rcs[0].Text != "" {
+					assistantMsg.SetExtraFields(map[string]any{
+						"reasoning_content": rcs[0].Text,
+					})
+				}
+			}
+
 			if len(msg.ToolCalls()) > 0 {
 				assistantMsg.ToolCalls = make(
 					[]openaisdk.ChatCompletionMessageToolCallUnionParam,
@@ -514,7 +529,9 @@ func (c *Client) preparedParams(
 		params.Tools = tools
 
 		if c.options.parallelToolCalls != nil {
-			params.ParallelToolCalls = openaisdk.Bool(*c.options.parallelToolCalls)
+			params.ParallelToolCalls = openaisdk.Bool(
+				*c.options.parallelToolCalls,
+			)
 		}
 
 		if c.options.toolChoice != nil {
@@ -663,8 +680,11 @@ func (c *Client) SendMessages(
 				finishReason = message.FinishReasonToolUse
 			}
 
+			reasoning := reasoningForChoice(openaiResponse.Choices[0])
+
 			resp := &llm.Response{
 				Content:          content,
+				Reasoning:        reasoning,
 				ToolCalls:        toolCalls,
 				Usage:            c.usage(*openaiResponse),
 				FinishReason:     finishReason,
@@ -744,6 +764,7 @@ func (c *Client) runStream(
 
 	acc := openaisdk.ChatCompletionAccumulator{}
 	currentContent := ""
+	thinkingText := ""
 	toolCalls := make([]message.ToolCall, 0)
 
 	for openaiStream.Next() {
@@ -757,6 +778,7 @@ func (c *Client) runStream(
 					var rc string
 					if json.Unmarshal([]byte(field.Raw()), &rc) == nil &&
 						rc != "" {
+						thinkingText += rc
 						eventChan <- llm.Event{
 							Type:     types.EventThinkingDelta,
 							Thinking: rc,
@@ -794,6 +816,7 @@ func (c *Client) runStream(
 
 		resp := &llm.Response{
 			Content:          currentContent,
+			Reasoning:        thinkingText,
 			ToolCalls:        toolCalls,
 			Usage:            c.usage(acc.ChatCompletion),
 			FinishReason:     finishReason,
@@ -834,6 +857,25 @@ func (c *Client) toolCallsForChoice(
 		})
 	}
 	return toolCalls
+}
+
+// reasoningForChoice extracts the reasoning content from a choice's extra fields.
+// Returns an empty string if no reasoning fields are present.
+func reasoningForChoice(
+	choice openaisdk.ChatCompletionChoice,
+) string {
+	for _, key := range []string{"reasoning", "reasoning_content"} {
+		if f, ok := choice.Message.JSON.ExtraFields[key]; ok {
+			raw := f.Raw()
+			if raw != "" && raw != "null" {
+				var rc string
+				if json.Unmarshal([]byte(raw), &rc) == nil && rc != "" {
+					return rc
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // logProbsForChoice maps a choice's logprobs.content block to the
@@ -1031,8 +1073,11 @@ func (c *Client) SendMessagesWithStructuredOutput(
 				finishReason = message.FinishReasonToolUse
 			}
 
+			reasoning := reasoningForChoice(openaiResponse.Choices[0])
+
 			resp := &llm.Response{
 				Content:                    content,
+				Reasoning:                  reasoning,
 				ToolCalls:                  toolCalls,
 				Usage:                      c.usage(*openaiResponse),
 				FinishReason:               finishReason,

--- a/llm/openai/reasoning_test.go
+++ b/llm/openai/reasoning_test.go
@@ -1,0 +1,299 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/schema"
+	"github.com/joakimcarlsson/ai/types"
+)
+
+// TestExtractReasoningSendMessages tests extracting reasoning content from
+// standard SendMessages non-streaming responses.
+func TestExtractReasoningSendMessages(t *testing.T) {
+	for _, key := range []string{"reasoning", "reasoning_content"} {
+		t.Run("key_"+key, func(t *testing.T) {
+			responseJSON := `{"id":"x","object":"chat.completion",` +
+				`"choices":[{"index":0,"message":{"role":"assistant","content":"final answer",` +
+				`"` + key + `":"thought process"},` +
+				`"finish_reason":"stop"}],` +
+				`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+			srv := newCompletionServer(t, nil, responseJSON)
+			defer srv.Close()
+
+			client := NewLLM(
+				WithAPIKey("test-key"),
+				WithBaseURL(srv.URL),
+				WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+			)
+
+			resp, err := client.SendMessages(
+				context.Background(),
+				[]message.Message{message.NewUserMessage("hi")},
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("SendMessages: %v", err)
+			}
+
+			if resp.Content != "final answer" {
+				t.Errorf("Content = %q, want %q", resp.Content, "final answer")
+			}
+			if resp.Reasoning != "thought process" {
+				t.Errorf(
+					"Reasoning = %q, want %q",
+					resp.Reasoning,
+					"thought process",
+				)
+			}
+		})
+	}
+}
+
+// TestExtractReasoningStructuredOutput tests extracting reasoning content from
+// SendMessagesWithStructuredOutput non-streaming responses.
+func TestExtractReasoningStructuredOutput(t *testing.T) {
+	responseJSON := `{"id":"x","object":"chat.completion",` +
+		`"choices":[{"index":0,"message":{"role":"assistant","content":"final answer",` +
+		`"reasoning_content":"structured thought"},` +
+		`"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+	srv := newCompletionServer(t, nil, responseJSON)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	schemaInfo := &schema.StructuredOutputInfo{
+		Name: "test_schema",
+		Parameters: map[string]any{
+			"type": "object",
+		},
+	}
+
+	resp, err := client.SendMessagesWithStructuredOutput(
+		context.Background(),
+		[]message.Message{message.NewUserMessage("hi")},
+		nil,
+		schemaInfo,
+	)
+	if err != nil {
+		t.Fatalf("SendMessagesWithStructuredOutput: %v", err)
+	}
+
+	if resp.Content != "final answer" {
+		t.Errorf("Content = %q, want %q", resp.Content, "final answer")
+	}
+	if resp.Reasoning != "structured thought" {
+		t.Errorf(
+			"Reasoning = %q, want %q",
+			resp.Reasoning,
+			"structured thought",
+		)
+	}
+}
+
+// TestAccumulateReasoningStream tests streaming reasoning content events
+// and checking the final compiled reasoning field.
+func TestAccumulateReasoningStream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			// Send first chunk with reasoning
+			_, _ = io.WriteString(
+				w,
+				"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"thinking \"}}]}\n\n",
+			)
+			// Send second chunk with reasoning and content
+			_, _ = io.WriteString(
+				w,
+				"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"more \",\"content\":\"hello\"}}]}\n\n",
+			)
+			// Send third chunk with content
+			_, _ = io.WriteString(
+				w,
+				"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"}}]}\n\n",
+			)
+			_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		}))
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	var events []llm.Event
+	for evt := range client.StreamResponse(context.Background(),
+		[]message.Message{message.NewUserMessage("hi")}, nil) {
+		events = append(events, evt)
+	}
+
+	// Verify events
+	var thinkingDeltas []string
+	var finalResponse *llm.Response
+
+	for _, evt := range events {
+		switch evt.Type {
+		case types.EventThinkingDelta:
+			thinkingDeltas = append(thinkingDeltas, evt.Thinking)
+		case types.EventComplete:
+			finalResponse = evt.Response
+		}
+	}
+
+	joinedThinking := strings.Join(thinkingDeltas, "")
+	if joinedThinking != "thinking more " {
+		t.Errorf(
+			"Thinking deltas combined = %q, want %q",
+			joinedThinking,
+			"thinking more ",
+		)
+	}
+
+	if finalResponse == nil {
+		t.Fatal("Expected EventComplete event, but got none")
+	}
+
+	if finalResponse.Content != "hello world" {
+		t.Errorf(
+			"finalResponse.Content = %q, want %q",
+			finalResponse.Content,
+			"hello world",
+		)
+	}
+
+	if finalResponse.Reasoning != "thinking more " {
+		t.Errorf(
+			"finalResponse.Reasoning = %q, want %q",
+			finalResponse.Reasoning,
+			"thinking more ",
+		)
+	}
+}
+
+// TestReplayReasoningContent tests that reasoning content is replayed
+// when WithReasoningContentReplay(true) is configured.
+func TestReplayReasoningContent(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+		WithReasoningContentReplay(true),
+	)
+
+	msg := message.NewAssistantMessage()
+	msg.AppendContent("final response text")
+	msg.AppendReasoningContent("internal thought text")
+
+	_, err := client.SendMessages(
+		context.Background(),
+		[]message.Message{msg},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	// Extract messages sent to the server
+	msgs, ok := body["messages"].([]any)
+	if !ok || len(msgs) == 0 {
+		t.Fatalf("No messages in request body: %v", body)
+	}
+
+	assistantMsg, ok := msgs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("First message is not map: %v", msgs[0])
+	}
+
+	if assistantMsg["role"] != "assistant" {
+		t.Errorf("Role = %v, want assistant", assistantMsg["role"])
+	}
+
+	if assistantMsg["content"] != "final response text" {
+		t.Errorf(
+			"Content = %v, want %q",
+			assistantMsg["content"],
+			"final response text",
+		)
+	}
+
+	if assistantMsg["reasoning_content"] != "internal thought text" {
+		t.Errorf(
+			"reasoning_content = %v, want %q",
+			assistantMsg["reasoning_content"],
+			"internal thought text",
+		)
+	}
+}
+
+// TestNoReplayReasoningContent tests that reasoning content is not replayed
+// by default (WithReasoningContentReplay(false) or omitted).
+func TestNoReplayReasoningContent(t *testing.T) {
+	var body map[string]any
+	srv := newCompletionServer(t, &body, completionOK)
+	defer srv.Close()
+
+	client := NewLLM(
+		WithAPIKey("test-key"),
+		WithBaseURL(srv.URL),
+		WithModel(model.Model{APIModel: "gpt-4o-mini"}),
+	)
+
+	msg := message.NewAssistantMessage()
+	msg.AppendContent("final response text")
+	msg.AppendReasoningContent("internal thought text")
+
+	_, err := client.SendMessages(
+		context.Background(),
+		[]message.Message{msg},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("SendMessages: %v", err)
+	}
+
+	// Extract messages sent to the server
+	msgs, ok := body["messages"].([]any)
+	if !ok || len(msgs) == 0 {
+		t.Fatalf("No messages in request body: %v", body)
+	}
+
+	assistantMsg, ok := msgs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("First message is not map: %v", msgs[0])
+	}
+
+	if assistantMsg["role"] != "assistant" {
+		t.Errorf("Role = %v, want assistant", assistantMsg["role"])
+	}
+
+	if assistantMsg["content"] != "final response text" {
+		t.Errorf(
+			"Content = %v, want %q",
+			assistantMsg["content"],
+			"final response text",
+		)
+	}
+
+	if val, exists := assistantMsg["reasoning_content"]; exists {
+		t.Errorf("reasoning_content was set to %v, want it to be omitted", val)
+	}
+}

--- a/message/base.go
+++ b/message/base.go
@@ -118,6 +118,19 @@ func (tc TextContent) String() string {
 
 func (TextContent) isPart() {}
 
+// ReasoningContent represents reasoning/thinking content within a message.
+type ReasoningContent struct {
+	// Text contains the actual reasoning content.
+	Text string `json:"text"`
+}
+
+// String returns the reasoning content as a string.
+func (rc ReasoningContent) String() string {
+	return rc.Text
+}
+
+func (ReasoningContent) isPart() {}
+
 // ImageURLContent represents an image referenced by URL within a message.
 type ImageURLContent struct {
 	// URL is the location of the image resource.
@@ -205,6 +218,32 @@ func (m *Message) Content() TextContent {
 		}
 	}
 	return TextContent{}
+}
+
+// ReasoningContent returns all reasoning content parts from the message.
+func (m *Message) ReasoningContent() []ReasoningContent {
+	var reasoningContents []ReasoningContent
+	for _, part := range m.Parts {
+		if c, ok := part.(ReasoningContent); ok {
+			reasoningContents = append(reasoningContents, c)
+		}
+	}
+	return reasoningContents
+}
+
+// AppendReasoningContent adds reasoning text content to the message.
+func (m *Message) AppendReasoningContent(delta string) {
+	found := false
+	for i, part := range m.Parts {
+		if c, ok := part.(ReasoningContent); ok {
+			m.Parts[i] = ReasoningContent{Text: c.Text + delta}
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.Parts = append(m.Parts, ReasoningContent{Text: delta})
+	}
 }
 
 // BinaryContent returns all binary content parts from the message.
@@ -332,6 +371,8 @@ func (m Message) MarshalJSON() ([]byte, error) {
 			typeName = "tool_call"
 		case ToolResult:
 			typeName = "tool_result"
+		case ReasoningContent:
+			typeName = "reasoning"
 		default:
 			typeName = "unknown"
 		}
@@ -396,6 +437,12 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 				return err
 			}
 			part = tr
+		case "reasoning":
+			var rc ReasoningContent
+			if err := json.Unmarshal(wrapper.Data, &rc); err != nil {
+				return err
+			}
+			part = rc
 		default:
 			continue
 		}

--- a/tests/agent/chat_test.go
+++ b/tests/agent/chat_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/joakimcarlsson/ai/agent"
 	llm "github.com/joakimcarlsson/ai/llm"
 	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
 )
 
 func TestOnToolError_Recovery(t *testing.T) {
@@ -779,5 +780,70 @@ func TestContinue_RecordsErrorOnSpan(t *testing.T) {
 	span := findSpan(spans, "invoke_agent")
 	if span != nil && span.Status.Code != codes.Error {
 		t.Error("expected error status on invoke_agent span")
+	}
+}
+
+func TestChat_Reasoning(t *testing.T) {
+	mock := newMockLLM(
+		mockResponse{
+			Reasoning:    "thinking about the user query",
+			Content:      "hello there",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+	)
+
+	store := session.MemoryStore()
+	ctx := context.Background()
+
+	a := agent.New(mock,
+		agent.WithSession("reasoning-session", store),
+	)
+
+	resp, err := a.Chat(ctx, "hello")
+	if err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+
+	if resp.Content != "hello there" {
+		t.Errorf("expected Content 'hello there', got %q", resp.Content)
+	}
+
+	if resp.Reasoning != "thinking about the user query" {
+		t.Errorf(
+			"expected Reasoning 'thinking about the user query', got %q",
+			resp.Reasoning,
+		)
+	}
+
+	sess, err := store.Load(ctx, "reasoning-session")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	msgs, err := sess.GetMessages(ctx, nil)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+
+	var assistantMsg *message.Message
+	for _, msg := range msgs {
+		if msg.Role == message.Assistant {
+			assistantMsg = &msg
+			break
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatal("expected assistant message in history, found none")
+	}
+	reasoningParts := assistantMsg.ReasoningContent()
+	if len(reasoningParts) != 1 {
+		t.Errorf(
+			"expected 1 reasoning content part, got %d",
+			len(reasoningParts),
+		)
+	} else if reasoningParts[0].Text != "thinking about the user query" {
+		t.Errorf(
+			"expected reasoning text 'thinking about the user query', got %q",
+			reasoningParts[0].Text,
+		)
 	}
 }

--- a/tests/agent/helpers_test.go
+++ b/tests/agent/helpers_test.go
@@ -22,6 +22,7 @@ import (
 
 type mockResponse struct {
 	Content      string
+	Reasoning    string
 	ToolCalls    []message.ToolCall
 	FinishReason message.FinishReason
 	Usage        llm.TokenUsage
@@ -74,6 +75,7 @@ func (m *mockLLM) SendMessages(
 	}
 	return &llm.Response{
 		Content:      resp.Content,
+		Reasoning:    resp.Reasoning,
 		ToolCalls:    resp.ToolCalls,
 		FinishReason: resp.FinishReason,
 		Usage:        resp.Usage,
@@ -103,6 +105,9 @@ func (m *mockLLM) StreamResponse(
 			ch <- llm.Event{Type: types.EventError, Error: resp.Err}
 			return
 		}
+		if resp.Reasoning != "" {
+			ch <- llm.Event{Type: types.EventThinkingDelta, Thinking: resp.Reasoning}
+		}
 		if resp.Content != "" {
 			ch <- llm.Event{Type: types.EventContentDelta, Content: resp.Content}
 		}
@@ -110,6 +115,7 @@ func (m *mockLLM) StreamResponse(
 			Type: types.EventComplete,
 			Response: &llm.Response{
 				Content:      resp.Content,
+				Reasoning:    resp.Reasoning,
 				ToolCalls:    resp.ToolCalls,
 				FinishReason: resp.FinishReason,
 				Usage:        resp.Usage,

--- a/tests/agent/hooks_test.go
+++ b/tests/agent/hooks_test.go
@@ -297,6 +297,45 @@ func TestPostModelCall_Modify(t *testing.T) {
 	}
 }
 
+func TestPostModelCall_Modify_Streaming(t *testing.T) {
+	hooks := agent.Hooks{
+		PostModelCall: func(_ context.Context, mc agent.ModelResponseContext) (agent.ModelResponseResult, error) {
+			modified := *mc.Response
+			modified.Content = "overridden by hook stream"
+			modified.Reasoning = "overridden by hook reasoning"
+			return agent.ModelResponseResult{
+				Action:   agent.HookModify,
+				Response: &modified,
+			}, nil
+		},
+	}
+
+	mock := newMockLLM(
+		mockResponse{Content: "original", Reasoning: "thinking original"},
+	)
+	a := agent.New(mock, agent.WithHooks(hooks))
+
+	var resp *agent.ChatResponse
+	for event := range a.ChatStream(context.Background(), "test") {
+		if event.Type == types.EventComplete {
+			resp = event.Response
+		}
+	}
+
+	if resp == nil {
+		t.Fatal("expected non-nil ChatResponse on EventComplete")
+	}
+	if resp.Content != "overridden by hook stream" {
+		t.Fatalf("expected 'overridden by hook stream', got %q", resp.Content)
+	}
+	if resp.Reasoning != "overridden by hook reasoning" {
+		t.Fatalf(
+			"expected 'overridden by hook reasoning', got %q",
+			resp.Reasoning,
+		)
+	}
+}
+
 func TestPostModelCall_OnError(t *testing.T) {
 	var hookFired bool
 	var hookError error

--- a/tests/agent/stream_test.go
+++ b/tests/agent/stream_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/joakimcarlsson/ai/agent"
 	llm "github.com/joakimcarlsson/ai/llm"
 	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/session"
 	"github.com/joakimcarlsson/ai/types"
 )
 
@@ -553,5 +554,92 @@ func TestChatStream_HookError_RecordsOnSpan(t *testing.T) {
 	}
 	if span.Status.Code != codes.Error {
 		t.Error("expected error status on span from hook error")
+	}
+}
+
+func TestChatStream_Reasoning(t *testing.T) {
+	mock := newMockLLM(
+		mockResponse{
+			Reasoning:    "thinking about the user query in stream",
+			Content:      "hello from stream",
+			FinishReason: message.FinishReasonEndTurn,
+		},
+	)
+
+	store := session.MemoryStore()
+	ctx := context.Background()
+
+	a := agent.New(mock,
+		agent.WithSession("reasoning-stream-session", store),
+	)
+
+	var thinkingEvents []string
+	var finalResponse *agent.ChatResponse
+
+	for evt := range a.ChatStream(ctx, "hello") {
+		switch evt.Type {
+		case types.EventThinkingDelta:
+			thinkingEvents = append(thinkingEvents, evt.Thinking)
+		case types.EventComplete:
+			finalResponse = evt.Response
+		}
+	}
+
+	if len(thinkingEvents) != 1 ||
+		thinkingEvents[0] != "thinking about the user query in stream" {
+		t.Errorf(
+			"expected EventThinkingDelta with 'thinking about the user query in stream', got %q",
+			thinkingEvents,
+		)
+	}
+
+	if finalResponse == nil {
+		t.Fatal("expected EventComplete with response, got nil")
+	}
+
+	if finalResponse.Content != "hello from stream" {
+		t.Errorf(
+			"expected final Content 'hello from stream', got %q",
+			finalResponse.Content,
+		)
+	}
+
+	if finalResponse.Reasoning != "thinking about the user query in stream" {
+		t.Errorf(
+			"expected final Reasoning 'thinking about the user query in stream', got %q",
+			finalResponse.Reasoning,
+		)
+	}
+
+	sess, err := store.Load(ctx, "reasoning-stream-session")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	msgs, err := sess.GetMessages(ctx, nil)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+
+	var assistantMsg *message.Message
+	for _, msg := range msgs {
+		if msg.Role == message.Assistant {
+			assistantMsg = &msg
+			break
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatal("expected assistant message in history, found none")
+	}
+	reasoningParts := assistantMsg.ReasoningContent()
+	if len(reasoningParts) != 1 {
+		t.Errorf(
+			"expected 1 reasoning content part, got %d",
+			len(reasoningParts),
+		)
+	} else if reasoningParts[0].Text != "thinking about the user query in stream" {
+		t.Errorf(
+			"expected reasoning text 'thinking about the user query in stream', got %q",
+			reasoningParts[0].Text,
+		)
 	}
 }

--- a/tests/message/message_test.go
+++ b/tests/message/message_test.go
@@ -509,3 +509,24 @@ func TestJSON_PreservesCreatedAt(t *testing.T) {
 		)
 	}
 }
+
+func TestJSON_RoundTrip_ReasoningContent(t *testing.T) {
+	orig := message.NewMessage(message.Assistant, []message.ContentPart{
+		message.ReasoningContent{Text: "thinking very hard..."},
+	})
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded message.Message
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	reasoning := decoded.ReasoningContent()
+	if len(reasoning) != 1 || reasoning[0].Text != "thinking very hard..." {
+		t.Errorf("expected 'thinking very hard...', got %v", reasoning)
+	}
+}

--- a/tests/tokens/counter_test.go
+++ b/tests/tokens/counter_test.go
@@ -263,3 +263,35 @@ func TestCountTokens_Deterministic(t *testing.T) {
 		)
 	}
 }
+
+func TestCountTokens_ReasoningContent(t *testing.T) {
+	c := newCounter(t)
+
+	msgWithout := message.NewMessage(message.Assistant, []message.ContentPart{})
+	resultWithout, err := c.CountTokens(
+		context.Background(),
+		tokens.CountOptions{Messages: []message.Message{msgWithout}},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	msgWith := message.NewMessage(message.Assistant, []message.ContentPart{
+		message.ReasoningContent{Text: "Thinking process here"},
+	})
+	resultWith, err := c.CountTokens(
+		context.Background(),
+		tokens.CountOptions{Messages: []message.Message{msgWith}},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	diff := resultWith.MessageTokens - resultWithout.MessageTokens
+	if diff <= 0 {
+		t.Errorf(
+			"expected token count to increase with ReasoningContent, got diff: %d",
+			diff,
+		)
+	}
+}

--- a/tests/tokens/summarize_test.go
+++ b/tests/tokens/summarize_test.go
@@ -1,0 +1,123 @@
+package tokens
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/joakimcarlsson/ai/llm"
+	"github.com/joakimcarlsson/ai/message"
+	"github.com/joakimcarlsson/ai/model"
+	"github.com/joakimcarlsson/ai/schema"
+	"github.com/joakimcarlsson/ai/tokens"
+	"github.com/joakimcarlsson/ai/tokens/summarize"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type mockSummarizerLLM struct {
+	lastMsgs []message.Message
+}
+
+func (m *mockSummarizerLLM) SendMessages(
+	_ context.Context,
+	msgs []message.Message,
+	_ []tool.BaseTool,
+) (*llm.Response, error) {
+	m.lastMsgs = msgs
+	return &llm.Response{
+		Content: "Mock summary",
+	}, nil
+}
+
+func (m *mockSummarizerLLM) SendMessagesWithStructuredOutput(
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
+	_ *schema.StructuredOutputInfo,
+) (*llm.Response, error) {
+	return nil, nil
+}
+
+func (m *mockSummarizerLLM) StreamResponse(
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
+) <-chan llm.Event {
+	return nil
+}
+
+func (m *mockSummarizerLLM) StreamResponseWithStructuredOutput(
+	_ context.Context,
+	_ []message.Message,
+	_ []tool.BaseTool,
+	_ *schema.StructuredOutputInfo,
+) <-chan llm.Event {
+	return nil
+}
+
+func (m *mockSummarizerLLM) Model() model.Model {
+	return model.Model{ID: "mock-summarizer"}
+}
+
+func (m *mockSummarizerLLM) SupportsStructuredOutput() bool {
+	return false
+}
+
+func TestSummarizeStrategy_SkipsReasoningContent(t *testing.T) {
+	mockLLM := &mockSummarizerLLM{}
+
+	// KeepRecent is 1. We will provide 2 messages so that summarization is triggered.
+	strategy := summarize.Strategy(mockLLM, summarize.KeepRecent(1))
+
+	counter, err := tokens.NewCounter()
+	if err != nil {
+		t.Fatalf("failed to create counter: %v", err)
+	}
+
+	// Message with reasoning content and text content.
+	msg := message.Message{
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.ReasoningContent{Text: "SECRET_THOUGHTS_DO_NOT_LEAK"},
+			message.TextContent{Text: "VISIBLE_RESPONSE_TO_USER"},
+		},
+	}
+
+	input := tokens.StrategyInput{
+		Messages: []message.Message{
+			msg,
+			message.NewUserMessage("User trigger"),
+		},
+		SystemPrompt: "System prompt",
+		MaxTokens:    10, // low max tokens to force Fit to summarize
+		Counter:      counter,
+	}
+
+	_, err = strategy.Fit(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Fit failed: %v", err)
+	}
+
+	if len(mockLLM.lastMsgs) < 2 {
+		t.Fatalf(
+			"expected summarizer LLM to receive system prompt and conversation messages, got %d messages",
+			len(mockLLM.lastMsgs),
+		)
+	}
+
+	summaryPrompt := mockLLM.lastMsgs[1].Content().Text
+
+	if strings.Contains(summaryPrompt, "SECRET_THOUGHTS_DO_NOT_LEAK") {
+		t.Errorf(
+			"expected summary prompt to skip reasoning content, but it was found: %q",
+			summaryPrompt,
+		)
+	}
+
+	if !strings.Contains(summaryPrompt, "VISIBLE_RESPONSE_TO_USER") {
+		t.Errorf(
+			"expected summary prompt to contain text content, but it was not found: %q",
+			summaryPrompt,
+		)
+	}
+}

--- a/tokens/counter.go
+++ b/tokens/counter.go
@@ -90,6 +90,8 @@ func (c *Counter) CountTokens(
 			case message.ToolResult:
 				result.MessageTokens += int64(c.tokenizer.Count(p.Content))
 				result.MessageTokens += ToolResultOverhead
+			case message.ReasoningContent:
+				result.MessageTokens += int64(c.tokenizer.Count(p.Text))
 			}
 		}
 	}

--- a/tokens/summarize/strategy.go
+++ b/tokens/summarize/strategy.go
@@ -154,6 +154,8 @@ func (s *summarizeStrategy) generateSummary(
 				fmt.Fprintf(&sb, "[Tool call: %s]", p.Name)
 			case message.ToolResult:
 				fmt.Fprintf(&sb, "[Tool result: %s]", p.Name)
+			case message.ReasoningContent:
+				// ReasoningContent is intentionally skipped to save tokens.
 			}
 		}
 		sb.WriteString("\n\n")


### PR DESCRIPTION
configuring models for Reasoning handling in openai compatible providers.

Configuration available for including reasoning
and controls for feeding reasoning content back to the llm to allow for different LLM handling of
reasoning chains.

In stream.go, updated the post-model-call HookModify to sync fullContent = finalResponse.Content
(and fullReasoning) to make stream.go consistent
with chat.go (where the hook's response wholly
replaces resp), correcting a pre-existing inconsistency. Previously a hook-modified response's content did
not replace the streamed deltas in ChatResponse.Content.