### PR TITLE
chore: version sync for reasoning propagation + image/azure release

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -3,12 +3,12 @@ module github.com/joakimcarlsson/ai/agent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/memory v0.2.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/memory v0.2.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0
-	github.com/joakimcarlsson/ai/session v0.1.2
-	github.com/joakimcarlsson/ai/tokens v0.2.3
+	github.com/joakimcarlsson/ai/session v0.1.3
+	github.com/joakimcarlsson/ai/tokens v0.2.4
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 	github.com/joakimcarlsson/ai/types v0.1.0

--- a/batch/anthropic/go.mod
+++ b/batch/anthropic/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
-	github.com/joakimcarlsson/ai/batch v0.1.4
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/batch v0.1.5
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )

--- a/batch/concurrent/go.mod
+++ b/batch/concurrent/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/batch/concurrent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.4
+	github.com/joakimcarlsson/ai/batch v0.1.5
 	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.4.3
+	github.com/joakimcarlsson/ai/llm v0.5.0
 )
 
 require (
@@ -16,7 +16,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.3.1 // indirect
+	github.com/joakimcarlsson/ai/message v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/batch/gemini/go.mod
+++ b/batch/gemini/go.mod
@@ -4,10 +4,10 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/batch v0.1.4
+	github.com/joakimcarlsson/ai/batch v0.1.5
 	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	google.golang.org/genai v1.61.0

--- a/batch/go.mod
+++ b/batch/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 

--- a/batch/openai/go.mod
+++ b/batch/openai/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/batch/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.4
+	github.com/joakimcarlsson/ai/batch v0.1.5
 	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/openai/openai-go/v3 v3.41.0

--- a/image/azure/go.mod
+++ b/image/azure/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/joakimcarlsson/ai/image v0.1.3
-	github.com/joakimcarlsson/ai/image/openai v0.1.3
+	github.com/joakimcarlsson/ai/image/openai v0.2.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/openai/openai-go/v3 v3.41.0
 )

--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/azure/go.mod
+++ b/llm/azure/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/openai/openai-go/v3 v3.41.0
 )

--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/bedrock
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/anthropic v0.3.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/anthropic v0.3.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/berget/go.mod
+++ b/llm/berget/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/cerebras
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.3.1 // indirect
+	github.com/joakimcarlsson/ai/message v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 )
 

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/fireworks
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.3.1 // indirect
+	github.com/joakimcarlsson/ai/message v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -4,8 +4,8 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/go.mod
+++ b/llm/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/llm
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/groq/go.mod
+++ b/llm/groq/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/groq
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.3.1 // indirect
+	github.com/joakimcarlsson/ai/message v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/ollama
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.3.1 // indirect
+	github.com/joakimcarlsson/ai/message v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/openrouter
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 )
 

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/perplexity
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 )
 

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/together
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.3.1 // indirect
+	github.com/joakimcarlsson/ai/message v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/vertexai
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/gemini v0.3.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/gemini v0.3.4
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	google.golang.org/genai v1.61.0
 )

--- a/llm/xai/go.mod
+++ b/llm/xai/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.4.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 

--- a/memory/pgvector/go.mod
+++ b/memory/pgvector/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/memory v0.2.4
+	github.com/joakimcarlsson/ai/memory v0.2.5
 	github.com/lib/pq v1.12.3
 )
 
@@ -16,8 +16,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/llm v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/message v0.3.1 // indirect
+	github.com/joakimcarlsson/ai/llm v0.5.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.4.0 // indirect
 	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect

--- a/memory/postgres/go.mod
+++ b/memory/postgres/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/message v0.3.1
-	github.com/joakimcarlsson/ai/session v0.1.2
+	github.com/joakimcarlsson/ai/message v0.4.0
+	github.com/joakimcarlsson/ai/session v0.1.3
 	github.com/lib/pq v1.12.3
 )
 

--- a/memory/sqlite/go.mod
+++ b/memory/sqlite/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/memory/sqlite
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.3.1
-	github.com/joakimcarlsson/ai/session v0.1.2
+	github.com/joakimcarlsson/ai/message v0.4.0
+	github.com/joakimcarlsson/ai/session v0.1.3
 )
 
 require github.com/joakimcarlsson/ai/model v0.6.0 // indirect

--- a/session/go.mod
+++ b/session/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/session
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/message v0.3.1
+require github.com/joakimcarlsson/ai/message v0.4.0
 
 require github.com/joakimcarlsson/ai/model v0.6.0 // indirect
 

--- a/tokens/go.mod
+++ b/tokens/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/tokens
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 

--- a/tokens/sliding/go.mod
+++ b/tokens/sliding/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tokens/sliding
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.3.1
-	github.com/joakimcarlsson/ai/tokens v0.2.3
+	github.com/joakimcarlsson/ai/message v0.4.0
+	github.com/joakimcarlsson/ai/tokens v0.2.4
 )
 
 require (

--- a/tokens/summarize/go.mod
+++ b/tokens/summarize/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/tokens/summarize
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/message v0.3.1
-	github.com/joakimcarlsson/ai/tokens v0.2.3
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/message v0.4.0
+	github.com/joakimcarlsson/ai/tokens v0.2.4
 )
 
 require (

--- a/tokens/truncate/go.mod
+++ b/tokens/truncate/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tokens/truncate
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.3.1
-	github.com/joakimcarlsson/ai/tokens v0.2.3
+	github.com/joakimcarlsson/ai/message v0.4.0
+	github.com/joakimcarlsson/ai/tokens v0.2.4
 )
 
 require (

--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,14 +3,14 @@ module github.com/joakimcarlsson/ai/voice
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/memory v0.2.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/memory v0.2.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.2
+	github.com/joakimcarlsson/ai/session v0.1.3
 	github.com/joakimcarlsson/ai/stt v0.2.3
-	github.com/joakimcarlsson/ai/tokens v0.2.3
+	github.com/joakimcarlsson/ai/tokens v0.2.4
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/tts v0.2.3
 	github.com/joakimcarlsson/ai/types v0.1.0


### PR DESCRIPTION
Prepares the release by re-pinning the `message`/`llm` dependent closure (37 modules) to this release's target versions, so each new tag references its siblings at their new tags (drift-gate consistent).

Feature content already on main:
- **Reasoning propagation** (#216): `message` gains `ReasoningContent` + `AppendReasoningContent`; `llm.Response` and `agent.ChatResponse` gain `Reasoning`.
- **image/azure** (#215): new provider mirroring `llm/azure`; `image/openai` gains `NewWithExistingClient`.

Version bumps: `message v0.4.0`, `llm v0.5.0`, `agent v0.4.0`, `image/openai v0.2.0` (minor); `image/azure v0.1.0` (new); the rest of the closure patch.

Verification: no self-requires, `sync-deps.sh --check` green, all modules build in workspace mode.