### PR TITLE
chore(tests): sync intra-repo requires to release tags

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,18 +3,18 @@ module github.com/joakimcarlsson/ai/tests
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/agent v0.3.5
+	github.com/joakimcarlsson/ai/agent v0.4.0
 	github.com/joakimcarlsson/ai/fim v0.2.1
-	github.com/joakimcarlsson/ai/llm v0.4.3
-	github.com/joakimcarlsson/ai/memory v0.2.4
-	github.com/joakimcarlsson/ai/message v0.3.1
+	github.com/joakimcarlsson/ai/llm v0.5.0
+	github.com/joakimcarlsson/ai/memory v0.2.5
+	github.com/joakimcarlsson/ai/message v0.4.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.2
+	github.com/joakimcarlsson/ai/session v0.1.3
 	github.com/joakimcarlsson/ai/stt v0.2.3
-	github.com/joakimcarlsson/ai/tokens v0.2.3
-	github.com/joakimcarlsson/ai/tokens/summarize v0.1.5
+	github.com/joakimcarlsson/ai/tokens v0.2.4
+	github.com/joakimcarlsson/ai/tokens/summarize v0.1.6
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 	github.com/joakimcarlsson/ai/tts v0.2.3


### PR DESCRIPTION
Follow-up to #217: the unpublished `tests` module was outside the rewrite closure, so once the release tags were pushed its requires went stale. Bumps `tests/go.mod` to the new tags. go.mod-only.