### PR TITLE
chore(tests): sync intra-repo requires to release tags

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,22 +3,22 @@ module github.com/joakimcarlsson/ai/tests
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/agent v0.4.0
+	github.com/joakimcarlsson/ai/agent v0.5.0
 	github.com/joakimcarlsson/ai/fim v0.2.1
-	github.com/joakimcarlsson/ai/llm v0.5.0
-	github.com/joakimcarlsson/ai/memory v0.2.5
-	github.com/joakimcarlsson/ai/message v0.4.0
+	github.com/joakimcarlsson/ai/llm v0.5.1
+	github.com/joakimcarlsson/ai/memory v0.2.6
+	github.com/joakimcarlsson/ai/message v0.5.0
 	github.com/joakimcarlsson/ai/model v0.6.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.3
+	github.com/joakimcarlsson/ai/session v0.1.4
 	github.com/joakimcarlsson/ai/stt v0.2.3
-	github.com/joakimcarlsson/ai/tokens v0.2.4
-	github.com/joakimcarlsson/ai/tokens/summarize v0.1.6
+	github.com/joakimcarlsson/ai/tokens v0.2.5
+	github.com/joakimcarlsson/ai/tokens/summarize v0.1.7
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 	github.com/joakimcarlsson/ai/tts v0.2.3
-	github.com/joakimcarlsson/ai/types v0.1.0
+	github.com/joakimcarlsson/ai/types v0.2.0
 	github.com/joakimcarlsson/ai/voice v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/log v0.20.0


### PR DESCRIPTION
Follow-up to #221: the unpublished `tests` module is outside the rewrite closure, so the release tags left its requires stale. Bumps `tests/go.mod`. go.mod-only.