### PR TITLE
chore: version sync for the model registry refresh release

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -3,12 +3,12 @@ module github.com/joakimcarlsson/ai/agent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/memory v0.2.6
-	github.com/joakimcarlsson/ai/message v0.5.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/memory v0.2.7
+	github.com/joakimcarlsson/ai/message v0.5.1
 	github.com/joakimcarlsson/ai/prompt v0.1.0
-	github.com/joakimcarlsson/ai/session v0.1.4
-	github.com/joakimcarlsson/ai/tokens v0.2.5
+	github.com/joakimcarlsson/ai/session v0.1.5
+	github.com/joakimcarlsson/ai/tokens v0.2.6
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 	github.com/joakimcarlsson/ai/types v0.2.0
@@ -22,8 +22,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.3 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.2.4 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/batch/anthropic/go.mod
+++ b/batch/anthropic/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
-	github.com/joakimcarlsson/ai/batch v0.1.6
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/batch v0.1.7
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 
@@ -22,7 +22,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.3 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.2.4 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect

--- a/batch/concurrent/go.mod
+++ b/batch/concurrent/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/batch/concurrent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.6
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.5.1
+	github.com/joakimcarlsson/ai/batch v0.1.7
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/llm v0.5.2
 )
 
 require (
@@ -16,8 +16,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.5.1 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/batch/gemini/go.mod
+++ b/batch/gemini/go.mod
@@ -4,11 +4,11 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/batch v0.1.6
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/batch v0.1.7
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	google.golang.org/genai v1.61.0
 )

--- a/batch/go.mod
+++ b/batch/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/batch
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 
@@ -17,7 +17,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect

--- a/batch/openai/go.mod
+++ b/batch/openai/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/batch/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.6
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/batch v0.1.7
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/openai/openai-go/v3 v3.41.0
 )

--- a/embeddings/bedrock/go.mod
+++ b/embeddings/bedrock/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/embeddings/berget/go.mod
+++ b/embeddings/berget/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/embeddings/openai v0.1.4
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/embeddings/openai v0.1.5
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
 	github.com/openai/openai-go/v3 v3.41.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/embeddings/cohere/go.mod
+++ b/embeddings/cohere/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/cohere
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/embeddings/gemini/go.mod
+++ b/embeddings/gemini/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/gemini
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 	google.golang.org/genai v1.61.0
 )
 

--- a/embeddings/go.mod
+++ b/embeddings/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 )
 

--- a/embeddings/mistral/go.mod
+++ b/embeddings/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/embeddings/openai/go.mod
+++ b/embeddings/openai/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/embeddings/voyage/go.mod
+++ b/embeddings/voyage/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/voyage
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/fim/deepseek/go.mod
+++ b/fim/deepseek/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/fim/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/fim v0.2.1
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/fim v0.2.2
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/fim/go.mod
+++ b/fim/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/fim
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 )
 

--- a/fim/mistral/go.mod
+++ b/fim/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/fim/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/fim v0.2.1
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/fim v0.2.2
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/image/azure/go.mod
+++ b/image/azure/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/joakimcarlsson/ai/image v0.1.3
-	github.com/joakimcarlsson/ai/image/openai v0.2.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/image v0.1.4
+	github.com/joakimcarlsson/ai/image/openai v0.2.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/image/gemini/go.mod
+++ b/image/gemini/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/image/gemini
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/image v0.1.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/image v0.1.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 	google.golang.org/genai v1.61.0
 )
 

--- a/image/go.mod
+++ b/image/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/image
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 )
 

--- a/image/openai/go.mod
+++ b/image/openai/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/image/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/image v0.1.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/image v0.1.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/image/xai/go.mod
+++ b/image/xai/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/image/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/image v0.1.3
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/image v0.1.4
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/types v0.2.0

--- a/llm/azure/go.mod
+++ b/llm/azure/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/bedrock
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/anthropic v0.3.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/anthropic v0.3.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/types v0.2.0

--- a/llm/berget/go.mod
+++ b/llm/berget/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/types v0.2.0

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/cerebras
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
 )
 
 require (
@@ -15,8 +15,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.5.1 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/fireworks
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
 )
 
 require (
@@ -15,8 +15,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.5.1 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -4,9 +4,9 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/types v0.2.0

--- a/llm/go.mod
+++ b/llm/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/tracing v0.1.1

--- a/llm/groq/go.mod
+++ b/llm/groq/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/groq
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/types v0.2.0

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
 )
 
 require (
@@ -15,8 +15,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.5.1 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/ollama
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
 )
 
 require (
@@ -15,8 +15,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.5.1 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/types v0.2.0

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/openrouter
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/perplexity
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 )
 
 require (

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/together
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
 )
 
 require (
@@ -15,8 +15,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.5.1 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/vertexai
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/gemini v0.3.5
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/gemini v0.3.6
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	google.golang.org/genai v1.61.0
 )
 

--- a/llm/xai/go.mod
+++ b/llm/xai/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/llm/openai v0.4.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/llm/openai v0.4.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.2
 	github.com/joakimcarlsson/ai/types v0.2.0

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect

--- a/memory/pgvector/go.mod
+++ b/memory/pgvector/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.3
-	github.com/joakimcarlsson/ai/memory v0.2.6
+	github.com/joakimcarlsson/ai/embeddings v0.2.4
+	github.com/joakimcarlsson/ai/memory v0.2.7
 	github.com/lib/pq v1.12.3
 )
 
@@ -16,9 +16,9 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/llm v0.5.1 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/llm v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.5.1 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/memory/postgres/go.mod
+++ b/memory/postgres/go.mod
@@ -4,12 +4,12 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/session v0.1.4
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/session v0.1.5
 	github.com/lib/pq v1.12.3
 )
 
-require github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+require github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 
 replace (
 	github.com/joakimcarlsson/ai/message => ../../message

--- a/memory/sqlite/go.mod
+++ b/memory/sqlite/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/memory/sqlite
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/session v0.1.4
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/session v0.1.5
 )
 
-require github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+require github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 
 replace (
 	github.com/joakimcarlsson/ai/message => ../../message

--- a/message/go.mod
+++ b/message/go.mod
@@ -2,6 +2,6 @@ module github.com/joakimcarlsson/ai/message
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/model v0.6.0
+require github.com/joakimcarlsson/ai/model v0.7.0
 
 replace github.com/joakimcarlsson/ai/model => ../model

--- a/rerankers/berget/go.mod
+++ b/rerankers/berget/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/rerankers/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/rerankers v0.2.1
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/rerankers v0.2.2
 )
 
 require (

--- a/rerankers/cohere/go.mod
+++ b/rerankers/cohere/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/rerankers/cohere
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/rerankers v0.2.1
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/rerankers v0.2.2
 )
 
 require (

--- a/rerankers/go.mod
+++ b/rerankers/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/rerankers
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 )
 

--- a/rerankers/voyage/go.mod
+++ b/rerankers/voyage/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/rerankers/voyage
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/rerankers v0.2.1
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/rerankers v0.2.2
 )
 
 require (

--- a/session/go.mod
+++ b/session/go.mod
@@ -2,9 +2,9 @@ module github.com/joakimcarlsson/ai/session
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/message v0.5.0
+require github.com/joakimcarlsson/ai/message v0.5.1
 
-require github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+require github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 
 replace (
 	github.com/joakimcarlsson/ai/message => ../message

--- a/stt/assemblyai/go.mod
+++ b/stt/assemblyai/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/stt v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/stt v0.2.4
 )
 
 require (

--- a/stt/azure/go.mod
+++ b/stt/azure/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/stt/azure
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/stt v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/stt v0.2.4
 )
 
 require (

--- a/stt/berget/go.mod
+++ b/stt/berget/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/stt/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/stt v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/stt v0.2.4
 )
 
 require (

--- a/stt/deepgram/go.mod
+++ b/stt/deepgram/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/stt v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/stt v0.2.4
 )
 
 require (

--- a/stt/elevenlabs/go.mod
+++ b/stt/elevenlabs/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/stt v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/stt v0.2.4
 )
 
 require (

--- a/stt/go.mod
+++ b/stt/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/stt
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 )
 

--- a/stt/google/go.mod
+++ b/stt/google/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/stt/google
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/stt v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/stt v0.2.4
 )
 
 require (

--- a/stt/openai/go.mod
+++ b/stt/openai/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/stt/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/stt v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/stt v0.2.4
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/tokens/go.mod
+++ b/tokens/go.mod
@@ -3,13 +3,13 @@ module github.com/joakimcarlsson/ai/tokens
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.0
+	github.com/joakimcarlsson/ai/message v0.5.1
 	github.com/joakimcarlsson/ai/tool v0.1.2
 )
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tokens/sliding/go.mod
+++ b/tokens/sliding/go.mod
@@ -3,13 +3,13 @@ module github.com/joakimcarlsson/ai/tokens/sliding
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/tokens v0.2.5
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/tokens v0.2.6
 )
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/tokens/summarize/go.mod
+++ b/tokens/summarize/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/tokens/summarize
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/tokens v0.2.5
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/tokens v0.2.6
 )
 
 require (
@@ -16,7 +16,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect

--- a/tokens/truncate/go.mod
+++ b/tokens/truncate/go.mod
@@ -3,13 +3,13 @@ module github.com/joakimcarlsson/ai/tokens/truncate
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/tokens v0.2.5
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/tokens v0.2.6
 )
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/model v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/model v0.7.0 // indirect
 	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/tts/azure/go.mod
+++ b/tts/azure/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tts/azure
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/tts v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/tts v0.2.4
 )
 
 require (

--- a/tts/deepgram/go.mod
+++ b/tts/deepgram/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/tts v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/tts v0.2.4
 )
 
 require (

--- a/tts/elevenlabs/go.mod
+++ b/tts/elevenlabs/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/tts v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/tts v0.2.4
 )
 
 require (

--- a/tts/go.mod
+++ b/tts/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/tts
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/tracing v0.1.1
 )
 

--- a/tts/google/go.mod
+++ b/tts/google/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tts/google
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/tts v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/tts v0.2.4
 )
 
 require (

--- a/tts/openai/go.mod
+++ b/tts/openai/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tts/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/model v0.6.0
-	github.com/joakimcarlsson/ai/tts v0.2.3
+	github.com/joakimcarlsson/ai/model v0.7.0
+	github.com/joakimcarlsson/ai/tts v0.2.4
 	github.com/openai/openai-go/v3 v3.41.0
 )
 

--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,16 +3,16 @@ module github.com/joakimcarlsson/ai/voice
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.1
-	github.com/joakimcarlsson/ai/memory v0.2.6
-	github.com/joakimcarlsson/ai/message v0.5.0
-	github.com/joakimcarlsson/ai/model v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.5.2
+	github.com/joakimcarlsson/ai/memory v0.2.7
+	github.com/joakimcarlsson/ai/message v0.5.1
+	github.com/joakimcarlsson/ai/model v0.7.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.4
-	github.com/joakimcarlsson/ai/stt v0.2.3
-	github.com/joakimcarlsson/ai/tokens v0.2.5
+	github.com/joakimcarlsson/ai/session v0.1.5
+	github.com/joakimcarlsson/ai/stt v0.2.4
+	github.com/joakimcarlsson/ai/tokens v0.2.6
 	github.com/joakimcarlsson/ai/tool v0.1.2
-	github.com/joakimcarlsson/ai/tts v0.2.3
+	github.com/joakimcarlsson/ai/tts v0.2.4
 	github.com/joakimcarlsson/ai/types v0.2.0
 	golang.org/x/sync v0.21.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.3 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.2.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect


### PR DESCRIPTION
Re-pins the `model` dependent closure (70 modules — everything except the `prompt`/`schema`/`tool`/`tracing`/`types` leaves) to this release's target versions, drift-gate consistent.

Feature content already on main (#223): model registry refreshed against live provider sources across 26 provider files — **26 new model constants** (Claude 5 Opus/Mythos, GPT-5.5 Pro, GPT-5.6 Sol/Terra/Luna, Gemini 3.6 Flash, Azure + OpenRouter mirrors, Fireworks MiniMax-M3 / Nemotron-3-Ultra, and more) plus refreshed pricing/context metadata.

Version bump: **`model v0.7.0`** (minor) — additive constants, and it drops `TogetherQwen36Plus`, which no longer exists upstream (verified unreferenced anywhere in the repo). The rest of the closure is patch.

Verification: no self-requires, `sync-deps.sh --check` green, **all modules and all examples build** in workspace mode.