### PR TITLE
feat(azure): add WithAttachments capability override

### DIFF
--- a/llm/azure/azure.go
+++ b/llm/azure/azure.go
@@ -33,6 +33,7 @@ type Options struct {
 	apiVersion            string
 	canReason             *bool
 	supportsStructuredOut *bool
+	attachments           *bool
 	httpClient            *http.Client
 }
 
@@ -128,6 +129,14 @@ func WithHTTPClient(c *http.Client) Option {
 // the deployment name does not match an entry in [model.AzureModels].
 func WithStructuredOutput(supportsStructuredOutput bool) Option {
 	return func(o *Options) { o.supportsStructuredOut = &supportsStructuredOutput }
+}
+
+// WithAttachments declares whether the deployed model accepts image
+// attachments. Azure routes on deployment name, so a deployment whose name
+// does not appear in [model.AzureModels] resolves to a model with every
+// capability false; this is how a caller states otherwise.
+func WithAttachments(supportsAttachments bool) Option {
+	return func(o *Options) { o.attachments = &supportsAttachments }
 }
 
 // Client implements [llm.LLM] against Azure OpenAI by delegating request handling
@@ -239,7 +248,7 @@ func NewLLM(opts ...Option) llm.LLM {
 //
 // Azure Foundry deployment names are opaque — callers whose deployment
 // doesn't match any registry entry should declare capabilities explicitly
-// via [WithReasoning] and [WithStructuredOutput].
+// via [WithReasoning], [WithStructuredOutput] and [WithAttachments].
 func resolveDeployment(deployment string) model.Model {
 	if deployment == "" {
 		return model.Model{}
@@ -259,7 +268,8 @@ func resolveDeployment(deployment string) model.Model {
 }
 
 // modelFromOptions resolves the deployment and applies any explicit
-// capability overrides from [WithReasoning] / [WithStructuredOutput].
+// capability overrides from [WithReasoning] / [WithStructuredOutput] /
+// [WithAttachments].
 func modelFromOptions(o Options) model.Model {
 	m := resolveDeployment(o.deployment)
 	if o.canReason != nil {
@@ -267,6 +277,9 @@ func modelFromOptions(o Options) model.Model {
 	}
 	if o.supportsStructuredOut != nil {
 		m.SupportsStructuredOut = *o.supportsStructuredOut
+	}
+	if o.attachments != nil {
+		m.SupportsAttachments = *o.attachments
 	}
 	return m
 }

--- a/llm/azure/azure_test.go
+++ b/llm/azure/azure_test.go
@@ -60,3 +60,51 @@ func TestWithHTTPClientTransportUsed(t *testing.T) {
 		t.Error("injected transport was not used for the request")
 	}
 }
+
+// TestWithAttachments covers the three states of the attachment-capability
+// override: unset leaves whatever resolveDeployment produced, an explicit true
+// declares support for a deployment name the registry cannot recognise, and an
+// explicit false overrides a table match that reports true.
+func TestWithAttachments(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []Option
+		want bool
+	}{
+		{
+			name: "unset on unknown deployment stays false",
+			opts: []Option{WithDeployment("unknown-deployment")},
+			want: false,
+		},
+		{
+			name: "explicit true on unknown deployment",
+			opts: []Option{
+				WithDeployment("unknown-deployment"),
+				WithAttachments(true),
+			},
+			want: true,
+		},
+		{
+			name: "explicit false overrides a table match",
+			opts: []Option{
+				WithDeployment("gpt-4o"),
+				WithAttachments(false),
+			},
+			want: false,
+		},
+		{
+			name: "unset on a table match keeps registry value",
+			opts: []Option{WithDeployment("gpt-4o")},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewLLM(tt.opts...).Model().SupportsAttachments
+			if got != tt.want {
+				t.Errorf("SupportsAttachments = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #226

## Problem

Azure OpenAI routes on the *deployment name*, which need not resemble any model id. `resolveDeployment` guesses capabilities by looking the deployment up in `model.AzureModels` (exact `APIModel` match, then substring fallback), and on no match returns a bare `model.Model` where every capability flag is the zero value `false`.

That guess is correctable for two of the three capability flags:

| flag | override |
| --- | --- |
| `CanReason` | `WithReasoning(bool)` |
| `SupportsStructuredOut` | `WithStructuredOutput(bool)` |
| `SupportsAttachments` | **none** (before this PR) |

So a caller with a vision-capable model deployed under a name the table does not know got a `model.Model` advertising `SupportsAttachments: false` with no recourse. Nothing in the repo reads the flag today, so no image is dropped; the bug is that the provider can publish capability metadata wrongly, and external callers that inspect `Model` to decide whether to attach an image get a wrong answer.

## Change

`llm/azure/azure.go` only, following the `WithStructuredOutput` precedent exactly:

- `attachments *bool` on `Options`, so "unset" stays distinguishable from an explicit `false`
- exported `WithAttachments(bool)` setter with a godoc comment
- a branch in `modelFromOptions`, applied after `resolveDeployment` so an explicit call always wins over the table lookup

No behaviour change for existing callers: an unset option leaves whatever `resolveDeployment` produced.

The no-match fallback still asserts `false` for all three flags. That is left as-is deliberately, per the issue: it is defensible now that an override exists for every flag, and changing it is a separate behaviour change.

## Tests

`TestWithAttachments` in `llm/azure/azure_test.go` is table-driven over four cases, asserting through the public surface (`NewLLM(...).Model().SupportsAttachments`):

- unset on an unknown deployment stays `false`
- explicit `true` on an unknown deployment yields `true`
- explicit `false` overrides the `gpt-4o` table match that reports `true`
- unset on the `gpt-4o` table match keeps the registry value `true`

## Verification

```
cd llm/azure
go test ./...        # ok
go vet ./...         # clean
golangci-lint run    # 0 issues
```
