### PR TITLE
chore: version sync for the model-dissolution release

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -3,14 +3,14 @@ module github.com/joakimcarlsson/ai/agent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/memory v0.2.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/memory v0.2.9
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0
-	github.com/joakimcarlsson/ai/session v0.1.6
-	github.com/joakimcarlsson/ai/tokens v0.2.7
-	github.com/joakimcarlsson/ai/tool v0.1.2
-	github.com/joakimcarlsson/ai/tracing v0.1.1
+	github.com/joakimcarlsson/ai/session v0.1.7
+	github.com/joakimcarlsson/ai/tokens v0.2.8
+	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/tracing v0.2.0
 	github.com/joakimcarlsson/ai/types v0.2.0
 )
 
@@ -22,7 +22,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.5 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/batch/anthropic/go.mod
+++ b/batch/anthropic/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.63.0
-	github.com/joakimcarlsson/ai/batch v0.1.8
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/batch v0.1.9
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tool v0.1.3
 )
 
 require (
@@ -21,9 +21,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.5 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.3.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect

--- a/batch/concurrent/go.mod
+++ b/batch/concurrent/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/batch/concurrent
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.8
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
-	github.com/joakimcarlsson/ai/llm v0.5.3
+	github.com/joakimcarlsson/ai/batch v0.1.9
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
+	github.com/joakimcarlsson/ai/llm v0.6.0
 )
 
 require (
@@ -16,10 +16,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/batch/gemini/go.mod
+++ b/batch/gemini/go.mod
@@ -4,11 +4,11 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/batch v0.1.8
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/batch v0.1.9
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	google.golang.org/genai v1.67.0
 )
 
@@ -29,7 +29,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/batch/go.mod
+++ b/batch/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/batch
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tool v0.1.3
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/batch/openai/go.mod
+++ b/batch/openai/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/batch/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.8
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/batch v0.1.9
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/embeddings/bedrock/go.mod
+++ b/embeddings/bedrock/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.36
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.57.2
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
 )
 
 require (
@@ -29,7 +29,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/embeddings/berget/go.mod
+++ b/embeddings/berget/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/embeddings/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
-	github.com/joakimcarlsson/ai/embeddings/openai v0.1.6
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
+	github.com/joakimcarlsson/ai/embeddings/openai v0.2.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/embeddings/cohere/go.mod
+++ b/embeddings/cohere/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/embeddings/cohere
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/embeddings v0.2.5
+require github.com/joakimcarlsson/ai/embeddings v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/embeddings/gemini/go.mod
+++ b/embeddings/gemini/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/gemini
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
 	google.golang.org/genai v1.67.0
 )
 
@@ -23,7 +23,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect

--- a/embeddings/go.mod
+++ b/embeddings/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/embeddings
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tracing v0.1.1
+require github.com/joakimcarlsson/ai/tracing v0.2.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/embeddings/mistral/go.mod
+++ b/embeddings/mistral/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/embeddings/mistral
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/embeddings v0.2.5
+require github.com/joakimcarlsson/ai/embeddings v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/embeddings/openai/go.mod
+++ b/embeddings/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/embeddings/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/embeddings/voyage/go.mod
+++ b/embeddings/voyage/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/embeddings/voyage
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/embeddings v0.2.5
+require github.com/joakimcarlsson/ai/embeddings v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/fim/deepseek/go.mod
+++ b/fim/deepseek/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/fim/deepseek
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/fim v0.2.3
+require github.com/joakimcarlsson/ai/fim v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/fim/go.mod
+++ b/fim/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/fim
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tracing v0.1.1
+require github.com/joakimcarlsson/ai/tracing v0.2.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/fim/mistral/go.mod
+++ b/fim/mistral/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/fim/mistral
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/fim v0.2.3
+require github.com/joakimcarlsson/ai/fim v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/image/azure/go.mod
+++ b/image/azure/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/joakimcarlsson/ai/image v0.2.0
-	github.com/joakimcarlsson/ai/image/openai v0.2.2
+	github.com/joakimcarlsson/ai/image v0.3.0
+	github.com/joakimcarlsson/ai/image/openai v0.3.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/image/gemini/go.mod
+++ b/image/gemini/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/image/gemini
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/image v0.2.0
+	github.com/joakimcarlsson/ai/image v0.3.0
 	google.golang.org/genai v1.67.0
 )
 
@@ -23,7 +23,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect

--- a/image/go.mod
+++ b/image/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/image
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tracing v0.1.1
+require github.com/joakimcarlsson/ai/tracing v0.2.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/image/openai/go.mod
+++ b/image/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/image/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/image v0.2.0
+	github.com/joakimcarlsson/ai/image v0.3.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/image/openrouter/go.mod
+++ b/image/openrouter/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/image/openrouter
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/image v0.2.0
+require github.com/joakimcarlsson/ai/image v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/image/xai/go.mod
+++ b/image/xai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/image/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/image v0.2.0
+	github.com/joakimcarlsson/ai/image v0.3.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.63.0
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/joakimcarlsson/ai/types v0.2.0
 )
 
@@ -37,7 +37,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/azure/go.mod
+++ b/llm/azure/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -23,8 +23,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect

--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/llm/bedrock
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/anthropic v0.3.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/anthropic v0.4.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/joakimcarlsson/ai/types v0.2.0
 )
 
@@ -38,7 +38,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/berget/go.mod
+++ b/llm/berget/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/llm/berget
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/joakimcarlsson/ai/types v0.2.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/cerebras
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
 )
 
 require (
@@ -15,10 +15,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/deepseek
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 )
 
 require (
@@ -17,8 +17,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/fireworks
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
 )
 
 require (
@@ -15,10 +15,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -4,10 +4,10 @@ go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/joakimcarlsson/ai/types v0.2.0
 	google.golang.org/genai v1.67.0
 )
@@ -28,7 +28,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/llm/go.mod
+++ b/llm/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
-	github.com/joakimcarlsson/ai/tracing v0.1.1
+	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/tracing v0.2.0
 	github.com/joakimcarlsson/ai/types v0.2.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/llm/groq/go.mod
+++ b/llm/groq/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/llm/groq
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/joakimcarlsson/ai/types v0.2.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
@@ -20,7 +20,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/mistral
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
 )
 
 require (
@@ -15,10 +15,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/ollama
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
 )
 
 require (
@@ -15,10 +15,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -3,10 +3,10 @@ module github.com/joakimcarlsson/ai/llm/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/joakimcarlsson/ai/types v0.2.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
@@ -19,7 +19,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/openrouter
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 )
 
 require (
@@ -17,8 +17,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/perplexity
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 )
 
 require (
@@ -17,8 +17,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/together
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
 )
 
 require (
@@ -15,10 +15,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/vertexai
 go 1.25.8
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/gemini v0.3.7
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/gemini v0.4.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	google.golang.org/genai v1.67.0
 )
 
@@ -27,8 +27,8 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/xai/go.mod
+++ b/llm/xai/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/llm/xai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/llm/openai v0.4.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/tool v0.1.3
 	github.com/joakimcarlsson/ai/types v0.2.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
@@ -20,7 +20,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tool v0.1.3
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/memory/pgvector/go.mod
+++ b/memory/pgvector/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/embeddings v0.2.5
-	github.com/joakimcarlsson/ai/memory v0.2.8
+	github.com/joakimcarlsson/ai/embeddings v0.3.0
+	github.com/joakimcarlsson/ai/memory v0.2.9
 	github.com/lib/pq v1.12.3
 )
 
@@ -16,11 +16,11 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/llm v0.5.3 // indirect
-	github.com/joakimcarlsson/ai/message v0.5.2 // indirect
+	github.com/joakimcarlsson/ai/llm v0.6.0 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/memory/postgres/go.mod
+++ b/memory/postgres/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/session v0.1.6
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/session v0.1.7
 	github.com/lib/pq v1.12.3
 )
 

--- a/memory/sqlite/go.mod
+++ b/memory/sqlite/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/memory/sqlite
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/session v0.1.6
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/session v0.1.7
 )
 
 replace (

--- a/rerankers/berget/go.mod
+++ b/rerankers/berget/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/rerankers/berget
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/rerankers v0.2.3
+require github.com/joakimcarlsson/ai/rerankers v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/rerankers/cohere/go.mod
+++ b/rerankers/cohere/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/rerankers/cohere
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/rerankers v0.2.3
+require github.com/joakimcarlsson/ai/rerankers v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/rerankers/go.mod
+++ b/rerankers/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/rerankers
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tracing v0.1.1
+require github.com/joakimcarlsson/ai/tracing v0.2.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/rerankers/voyage/go.mod
+++ b/rerankers/voyage/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/rerankers/voyage
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/rerankers v0.2.3
+require github.com/joakimcarlsson/ai/rerankers v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/session/go.mod
+++ b/session/go.mod
@@ -2,6 +2,6 @@ module github.com/joakimcarlsson/ai/session
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/message v0.5.2
+require github.com/joakimcarlsson/ai/message v0.6.0
 
 replace github.com/joakimcarlsson/ai/message => ../message

--- a/stt/assemblyai/go.mod
+++ b/stt/assemblyai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/stt v0.2.5
+	github.com/joakimcarlsson/ai/stt v0.3.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/stt/azure/go.mod
+++ b/stt/azure/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/stt/azure
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/stt v0.2.5
+require github.com/joakimcarlsson/ai/stt v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/stt/berget/go.mod
+++ b/stt/berget/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/stt/berget
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/stt v0.2.5
+require github.com/joakimcarlsson/ai/stt v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/stt/deepgram/go.mod
+++ b/stt/deepgram/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/stt v0.2.5
+	github.com/joakimcarlsson/ai/stt v0.3.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/stt/elevenlabs/go.mod
+++ b/stt/elevenlabs/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/stt v0.2.5
+	github.com/joakimcarlsson/ai/stt v0.3.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/stt/go.mod
+++ b/stt/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/stt
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tracing v0.1.1
+require github.com/joakimcarlsson/ai/tracing v0.2.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/stt/google/go.mod
+++ b/stt/google/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/stt/google
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/stt v0.2.5
+require github.com/joakimcarlsson/ai/stt v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/stt/openai/go.mod
+++ b/stt/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/stt/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/stt v0.2.5
+	github.com/joakimcarlsson/ai/stt v0.3.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/stt/openrouter/go.mod
+++ b/stt/openrouter/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/stt/openrouter
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/stt v0.2.5
-	github.com/joakimcarlsson/ai/stt/openai v0.1.5
+	github.com/joakimcarlsson/ai/stt v0.3.0
+	github.com/joakimcarlsson/ai/stt/openai v0.2.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/tokens/go.mod
+++ b/tokens/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tokens
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tool v0.1.2
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tool v0.1.3
 )
 
 require (

--- a/tokens/sliding/go.mod
+++ b/tokens/sliding/go.mod
@@ -3,13 +3,13 @@ module github.com/joakimcarlsson/ai/tokens/sliding
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tokens v0.2.7
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tokens v0.2.8
 )
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tokens/summarize/go.mod
+++ b/tokens/summarize/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/tokens/summarize
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tokens v0.2.7
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tokens v0.2.8
 )
 
 require (
@@ -17,8 +17,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/tokens/truncate/go.mod
+++ b/tokens/truncate/go.mod
@@ -3,13 +3,13 @@ module github.com/joakimcarlsson/ai/tokens/truncate
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/tokens v0.2.7
+	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/tokens v0.2.8
 )
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.2 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tts/azure/go.mod
+++ b/tts/azure/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/tts/azure
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tts v0.2.5
+require github.com/joakimcarlsson/ai/tts v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/tts/deepgram/go.mod
+++ b/tts/deepgram/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/tts v0.2.5
+	github.com/joakimcarlsson/ai/tts v0.3.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/tts/elevenlabs/go.mod
+++ b/tts/elevenlabs/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/joakimcarlsson/ai/tts v0.2.5
+	github.com/joakimcarlsson/ai/tts v0.3.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/tts/go.mod
+++ b/tts/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/tts
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tracing v0.1.1
+require github.com/joakimcarlsson/ai/tracing v0.2.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/tts/google/go.mod
+++ b/tts/google/go.mod
@@ -2,7 +2,7 @@ module github.com/joakimcarlsson/ai/tts/google
 
 go 1.25.0
 
-require github.com/joakimcarlsson/ai/tts v0.2.5
+require github.com/joakimcarlsson/ai/tts v0.3.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 // indirect

--- a/tts/openai/go.mod
+++ b/tts/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/joakimcarlsson/ai/tts/openai
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/tts v0.2.5
+	github.com/joakimcarlsson/ai/tts v0.3.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/tts/openrouter/go.mod
+++ b/tts/openrouter/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/tts/openrouter
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/tts v0.2.5
-	github.com/joakimcarlsson/ai/tts/openai v0.2.0
+	github.com/joakimcarlsson/ai/tts v0.3.0
+	github.com/joakimcarlsson/ai/tts/openai v0.3.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/openai/openai-go/v3 v3.50.0 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,15 +3,15 @@ module github.com/joakimcarlsson/ai/voice
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/memory v0.2.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/memory v0.2.9
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.6
-	github.com/joakimcarlsson/ai/stt v0.2.5
-	github.com/joakimcarlsson/ai/tokens v0.2.7
-	github.com/joakimcarlsson/ai/tool v0.1.2
-	github.com/joakimcarlsson/ai/tts v0.2.5
+	github.com/joakimcarlsson/ai/session v0.1.7
+	github.com/joakimcarlsson/ai/stt v0.3.0
+	github.com/joakimcarlsson/ai/tokens v0.2.8
+	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/tts v0.3.0
 	github.com/joakimcarlsson/ai/types v0.2.0
 	golang.org/x/sync v0.22.0
 )
@@ -24,8 +24,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.5 // indirect
-	github.com/joakimcarlsson/ai/tracing v0.1.1 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.3.0 // indirect
+	github.com/joakimcarlsson/ai/tracing v0.2.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect


### PR DESCRIPTION
Re-pins every module (76) to this release's target versions, drift-gate consistent.

Feature content already on main:
- **`refactor!`: the `model` module is dissolved into per-provider catalogs** (#233). Each provider owns its catalog (`openai.Models[openai.GPT4o]` instead of `model.OpenAIModels[model.GPT4o]`), and the shared shapes move to the packages that consume them (`llm.Model`, `embeddings.EmbeddingModel`, `rerankers.RerankerModel`, `tts.AudioModel`, `stt.TranscriptionModel`, `image.GenerationModel`). A model update now touches one module and needs one tag instead of cascading through 114 go.mod files.
- **`cmd/modelsync`** (#235): new tool that regenerates the per-provider catalogs from provider APIs.
- **Dependency refresh** (#232).

Version policy for this release: modules with source changes take a **minor** bump (breaking under v0.x) — 60 of them, including `llm v0.6.0`, `embeddings v0.3.0`, `image v0.3.0`, `rerankers v0.3.0`, `stt v0.3.0`, `tts v0.3.0`, `llm/openai v0.5.0`. Dep-only modules take a patch. `cmd/modelsync` starts at `v0.1.0`.

`model` is **not** tagged — the module no longer exists. Its existing tags remain resolvable for pinned consumers.

Verification: no self-requires, no lingering `ai/model` requires, `sync-deps.sh --check` green, all modules **and** examples build, `cmd/modelsync` lints clean.