### PR TITLE
chore(tests): sync intra-repo requires to release tags

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,22 +3,22 @@ module github.com/joakimcarlsson/ai/tests
 go 1.25.0
 
 require (
-	github.com/joakimcarlsson/ai/agent v0.5.2
-	github.com/joakimcarlsson/ai/fim v0.2.3
-	github.com/joakimcarlsson/ai/llm v0.5.3
-	github.com/joakimcarlsson/ai/memory v0.2.8
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/agent v0.5.3
+	github.com/joakimcarlsson/ai/fim v0.3.0
+	github.com/joakimcarlsson/ai/llm v0.6.0
+	github.com/joakimcarlsson/ai/memory v0.2.9
+	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/prompt v0.1.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.6
-	github.com/joakimcarlsson/ai/stt v0.2.5
-	github.com/joakimcarlsson/ai/tokens v0.2.7
-	github.com/joakimcarlsson/ai/tokens/summarize v0.1.9
-	github.com/joakimcarlsson/ai/tool v0.1.2
-	github.com/joakimcarlsson/ai/tracing v0.1.1
-	github.com/joakimcarlsson/ai/tts v0.2.5
+	github.com/joakimcarlsson/ai/session v0.1.7
+	github.com/joakimcarlsson/ai/stt v0.3.0
+	github.com/joakimcarlsson/ai/tokens v0.2.8
+	github.com/joakimcarlsson/ai/tokens/summarize v0.1.10
+	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/tracing v0.2.0
+	github.com/joakimcarlsson/ai/tts v0.3.0
 	github.com/joakimcarlsson/ai/types v0.2.0
-	github.com/joakimcarlsson/ai/voice v0.2.9
+	github.com/joakimcarlsson/ai/voice v0.2.10
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/log v0.21.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -34,7 +34,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/embeddings v0.2.5 // indirect
+	github.com/joakimcarlsson/ai/embeddings v0.3.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect


### PR DESCRIPTION
Follow-up to #236: the unpublished `tests` module sits outside the rewrite closure, so the 76 new release tags left 14 of its requires stale. Bumps `tests/go.mod`; drift check green and `tests` vets clean in workspace mode. go.mod-only.