### PR TITLE
chore: version sync for the modelsync catalog refresh

### DIFF
--- a/embeddings/berget/go.mod
+++ b/embeddings/berget/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/embeddings v0.3.0
-	github.com/joakimcarlsson/ai/embeddings/openai v0.2.0
+	github.com/joakimcarlsson/ai/embeddings/openai v0.2.1
 )
 
 require (

--- a/image/azure/go.mod
+++ b/image/azure/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/joakimcarlsson/ai/image v0.3.0
-	github.com/joakimcarlsson/ai/image/openai v0.3.0
+	github.com/joakimcarlsson/ai/image/openai v0.4.0
 	github.com/openai/openai-go/v3 v3.50.0
 )
 

--- a/llm/azure/go.mod
+++ b/llm/azure/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/openai/openai-go/v3 v3.50.0
 )

--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/anthropic v0.4.0
+	github.com/joakimcarlsson/ai/llm/anthropic v0.5.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.3

--- a/llm/berget/go.mod
+++ b/llm/berget/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.3

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 )
 
 require (

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 )
 

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 )
 
 require (

--- a/llm/groq/go.mod
+++ b/llm/groq/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.3

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 )
 
 require (

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 )
 
 require (

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 )
 

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 )
 

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 )
 
 require (

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/gemini v0.4.0
+	github.com/joakimcarlsson/ai/llm/gemini v0.5.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 	google.golang.org/genai v1.67.0
 )

--- a/llm/xai/go.mod
+++ b/llm/xai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/llm v0.6.0
-	github.com/joakimcarlsson/ai/llm/openai v0.5.0
+	github.com/joakimcarlsson/ai/llm/openai v0.6.0
 	github.com/joakimcarlsson/ai/message v0.6.0
 	github.com/joakimcarlsson/ai/schema v0.2.0
 	github.com/joakimcarlsson/ai/tool v0.1.3

--- a/stt/openrouter/go.mod
+++ b/stt/openrouter/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/stt v0.3.0
-	github.com/joakimcarlsson/ai/stt/openai v0.2.0
+	github.com/joakimcarlsson/ai/stt/openai v0.3.0
 )
 
 require (

--- a/tts/openrouter/go.mod
+++ b/tts/openrouter/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joakimcarlsson/ai/tts v0.3.0
-	github.com/joakimcarlsson/ai/tts/openai v0.3.0
+	github.com/joakimcarlsson/ai/tts/openai v0.4.0
 )
 
 require (


### PR DESCRIPTION
Bumps the 18 wrapper modules that require a base provider module being published in this release (`llm/*` wrappers → `llm/openai`/`llm/anthropic`/`llm/gemini`, `stt/openrouter` → `stt/openai`, `tts/openrouter` → `tts/openai`, `image/azure` → `image/openai`, `embeddings/berget` → `embeddings/openai`).

Feature content already on main (#244): `cmd/modelsync` extended (models.dev + OpenRouter + Berget sources, naming/field/catalog handling) and **all provider catalogs regenerated** — 46 provider modules' `models.go` refreshed with new models, removals of retired ones, and updated pricing/context metadata.

**This is the first release since the `model` dissolution, and the payoff shows:** a catalog refresh now needs **47 tags and no fleet-wide cascade** (previously every one of ~76 modules had to be re-pinned and re-tagged). Verified: nothing outside the changed set requires anything inside it — consumers depend on the `llm`/`embeddings`/`stt`/`tts`/`image` interfaces, not on provider catalogs.

Versions: 42 minor (catalogs whose exported constants changed, plus `cmd/modelsync v0.2.0`), 5 patch (metadata/pricing only: `embeddings/berget`, `embeddings/openai`, `rerankers/berget`, `stt/berget`, `stt/elevenlabs`).

Verification: no self-requires, `sync-deps.sh --check` green, all modules **and** examples build, `cmd/modelsync` lints clean.