### PR TITLE
chore: move the remaining modules to Go 1.26

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -3,15 +3,15 @@ module github.com/joakimcarlsson/ai/agent
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/memory v0.2.10
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/prompt v0.1.0
-	github.com/joakimcarlsson/ai/session v0.1.7
-	github.com/joakimcarlsson/ai/tokens v0.2.8
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/memory v0.2.11
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/prompt v0.1.1
+	github.com/joakimcarlsson/ai/session v0.1.8
+	github.com/joakimcarlsson/ai/tokens v0.2.9
+	github.com/joakimcarlsson/ai/tool v0.1.4
 	github.com/joakimcarlsson/ai/tracing v0.2.1
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/types v0.2.1
 )
 
 require (
@@ -23,7 +23,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/joakimcarlsson/ai/embeddings v0.3.1 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/batch/anthropic/go.mod
+++ b/batch/anthropic/go.mod
@@ -4,10 +4,10 @@ go 1.26.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.72.0
-	github.com/joakimcarlsson/ai/batch v0.1.10
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/batch v0.1.11
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
 )
 
 require (
@@ -22,9 +22,9 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/joakimcarlsson/ai/embeddings v0.3.1 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/batch/concurrent/go.mod
+++ b/batch/concurrent/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/batch/concurrent
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.10
+	github.com/joakimcarlsson/ai/batch v0.1.11
 	github.com/joakimcarlsson/ai/embeddings v0.3.1
-	github.com/joakimcarlsson/ai/llm v0.6.1
+	github.com/joakimcarlsson/ai/llm v0.6.2
 )
 
 require (
@@ -16,11 +16,11 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.1 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/batch/gemini/go.mod
+++ b/batch/gemini/go.mod
@@ -4,11 +4,11 @@ go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/batch v0.1.10
+	github.com/joakimcarlsson/ai/batch v0.1.11
 	github.com/joakimcarlsson/ai/embeddings v0.3.1
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
 	google.golang.org/genai v1.71.0
 )
 
@@ -28,9 +28,9 @@ require (
 	github.com/googleapis/gax-go/v2 v2.24.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/batch/go.mod
+++ b/batch/go.mod
@@ -4,9 +4,9 @@ go 1.26.0
 
 require (
 	github.com/joakimcarlsson/ai/embeddings v0.3.1
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
 )
 
 require (
@@ -17,9 +17,9 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/batch/openai/go.mod
+++ b/batch/openai/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/batch/openai
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/batch v0.1.10
+	github.com/joakimcarlsson/ai/batch v0.1.11
 	github.com/joakimcarlsson/ai/embeddings v0.3.1
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
 	github.com/openai/openai-go/v3 v3.61.0
 )
 
@@ -19,9 +19,9 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/cmd/llmstxt/go.mod
+++ b/cmd/llmstxt/go.mod
@@ -1,6 +1,6 @@
 module github.com/joakimcarlsson/ai/cmd/llmstxt
 
-go 1.25.0
+go 1.26.0
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/cmd/modelsync/go.mod
+++ b/cmd/modelsync/go.mod
@@ -1,3 +1,3 @@
 module github.com/joakimcarlsson/ai/cmd/modelsync
 
-go 1.25.0
+go 1.26.0

--- a/examples/model/pricing/go.mod
+++ b/examples/model/pricing/go.mod
@@ -1,6 +1,6 @@
 module github.com/joakimcarlsson/ai/examples/model/pricing
 
-go 1.25.8
+go 1.26.0
 
 require (
 	github.com/joakimcarlsson/ai/embeddings/voyage v0.1.6

--- a/examples/prompt/embed-templates/go.mod
+++ b/examples/prompt/embed-templates/go.mod
@@ -1,6 +1,6 @@
 module github.com/joakimcarlsson/ai/examples/prompt/embed-templates
 
-go 1.25.0
+go 1.26.0
 
 require github.com/joakimcarlsson/ai/prompt v0.1.0
 

--- a/examples/tokens/truncate/go.mod
+++ b/examples/tokens/truncate/go.mod
@@ -1,6 +1,6 @@
 module github.com/joakimcarlsson/ai/examples/tokens/truncate
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/joakimcarlsson/ai/message v0.5.2

--- a/llm/anthropic/go.mod
+++ b/llm/anthropic/go.mod
@@ -4,11 +4,11 @@ go 1.26.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.72.0
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
+	github.com/joakimcarlsson/ai/types v0.2.1
 )
 
 require (

--- a/llm/azure/go.mod
+++ b/llm/azure/go.mod
@@ -4,9 +4,9 @@ go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.1
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
-	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
+	github.com/joakimcarlsson/ai/message v0.6.1
 	github.com/openai/openai-go/v3 v3.61.0
 )
 
@@ -22,10 +22,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/llm/bedrock/go.mod
+++ b/llm/bedrock/go.mod
@@ -3,12 +3,12 @@ module github.com/joakimcarlsson/ai/llm/bedrock
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/anthropic v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/anthropic v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
+	github.com/joakimcarlsson/ai/types v0.2.1
 )
 
 require (

--- a/llm/berget/go.mod
+++ b/llm/berget/go.mod
@@ -3,12 +3,12 @@ module github.com/joakimcarlsson/ai/llm/berget
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
+	github.com/joakimcarlsson/ai/types v0.2.1
 )
 
 require (

--- a/llm/cerebras/go.mod
+++ b/llm/cerebras/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/cerebras
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
 )
 
 require (
@@ -15,11 +15,11 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.1 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/deepseek/go.mod
+++ b/llm/deepseek/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/deepseek
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
-	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
+	github.com/joakimcarlsson/ai/message v0.6.1
 )
 
 require (
@@ -16,10 +16,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/fireworks/go.mod
+++ b/llm/fireworks/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/fireworks
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
 )
 
 require (
@@ -15,11 +15,11 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.1 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/gemini/go.mod
+++ b/llm/gemini/go.mod
@@ -4,11 +4,11 @@ go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
+	github.com/joakimcarlsson/ai/types v0.2.1
 	google.golang.org/genai v1.71.0
 )
 

--- a/llm/go.mod
+++ b/llm/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/llm
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
 	github.com/joakimcarlsson/ai/tracing v0.2.1
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/types v0.2.1
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/trace v1.46.0
 )

--- a/llm/groq/go.mod
+++ b/llm/groq/go.mod
@@ -3,12 +3,12 @@ module github.com/joakimcarlsson/ai/llm/groq
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
+	github.com/joakimcarlsson/ai/types v0.2.1
 	github.com/openai/openai-go/v3 v3.61.0
 )
 

--- a/llm/mistral/go.mod
+++ b/llm/mistral/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/mistral
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
 )
 
 require (
@@ -15,11 +15,11 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.1 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/ollama/go.mod
+++ b/llm/ollama/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/ollama
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
 )
 
 require (
@@ -15,11 +15,11 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.1 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/openai/go.mod
+++ b/llm/openai/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/ai/llm/openai
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
+	github.com/joakimcarlsson/ai/types v0.2.1
 	github.com/openai/openai-go/v3 v3.61.0
 )
 

--- a/llm/openrouter/go.mod
+++ b/llm/openrouter/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/openrouter
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
-	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
+	github.com/joakimcarlsson/ai/message v0.6.1
 )
 
 require (
@@ -16,10 +16,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/perplexity/go.mod
+++ b/llm/perplexity/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/perplexity
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
-	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
+	github.com/joakimcarlsson/ai/message v0.6.1
 )
 
 require (
@@ -16,10 +16,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/together/go.mod
+++ b/llm/together/go.mod
@@ -3,8 +3,8 @@ module github.com/joakimcarlsson/ai/llm/together
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
 )
 
 require (
@@ -15,11 +15,11 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.1 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/openai/openai-go/v3 v3.61.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/llm/vertexai/go.mod
+++ b/llm/vertexai/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/llm/vertexai
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/gemini v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/gemini v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
 	google.golang.org/genai v1.71.0
 )
 
@@ -26,10 +26,10 @@ require (
 	github.com/googleapis/gax-go/v2 v2.24.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/llm/xai/go.mod
+++ b/llm/xai/go.mod
@@ -3,12 +3,12 @@ module github.com/joakimcarlsson/ai/llm/xai
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/llm/openai v0.8.0
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/llm/openai v0.8.1
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
+	github.com/joakimcarlsson/ai/types v0.2.1
 	github.com/openai/openai-go/v3 v3.61.0
 )
 

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -5,9 +5,9 @@ go 1.26.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joakimcarlsson/ai/embeddings v0.3.1
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
 )
 
 require (
@@ -17,9 +17,9 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/memory/pgvector/go.mod
+++ b/memory/pgvector/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joakimcarlsson/ai/embeddings v0.3.1
-	github.com/joakimcarlsson/ai/memory v0.2.10
+	github.com/joakimcarlsson/ai/memory v0.2.11
 	github.com/lib/pq v1.12.3
 )
 
@@ -16,12 +16,12 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/llm v0.6.1 // indirect
-	github.com/joakimcarlsson/ai/message v0.6.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/llm v0.6.2 // indirect
+	github.com/joakimcarlsson/ai/message v0.6.1 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/memory/postgres/go.mod
+++ b/memory/postgres/go.mod
@@ -1,11 +1,11 @@
 module github.com/joakimcarlsson/ai/memory/postgres
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/session v0.1.7
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/session v0.1.8
 	github.com/lib/pq v1.12.3
 )
 

--- a/memory/sqlite/go.mod
+++ b/memory/sqlite/go.mod
@@ -1,10 +1,10 @@
 module github.com/joakimcarlsson/ai/memory/sqlite
 
-go 1.25.0
+go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/session v0.1.7
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/session v0.1.8
 )
 
 replace (

--- a/message/go.mod
+++ b/message/go.mod
@@ -1,3 +1,3 @@
 module github.com/joakimcarlsson/ai/message
 
-go 1.25.0
+go 1.26.0

--- a/prompt/go.mod
+++ b/prompt/go.mod
@@ -1,3 +1,3 @@
 module github.com/joakimcarlsson/ai/prompt
 
-go 1.25.0
+go 1.26.0

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -1,3 +1,3 @@
 module github.com/joakimcarlsson/ai/schema
 
-go 1.25.0
+go 1.26.0

--- a/session/go.mod
+++ b/session/go.mod
@@ -1,7 +1,7 @@
 module github.com/joakimcarlsson/ai/session
 
-go 1.25.0
+go 1.26.0
 
-require github.com/joakimcarlsson/ai/message v0.6.0
+require github.com/joakimcarlsson/ai/message v0.6.1
 
 replace github.com/joakimcarlsson/ai/message => ../message

--- a/tokens/go.mod
+++ b/tokens/go.mod
@@ -1,10 +1,10 @@
 module github.com/joakimcarlsson/ai/tokens
 
-go 1.25.0
+go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tool v0.1.4
 )
 
 require (

--- a/tokens/sliding/go.mod
+++ b/tokens/sliding/go.mod
@@ -1,15 +1,15 @@
 module github.com/joakimcarlsson/ai/tokens/sliding
 
-go 1.25.0
+go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tokens v0.2.8
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tokens v0.2.9
 )
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tokens/summarize/go.mod
+++ b/tokens/summarize/go.mod
@@ -3,9 +3,9 @@ module github.com/joakimcarlsson/ai/tokens/summarize
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tokens v0.2.8
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tokens v0.2.9
 )
 
 require (
@@ -16,10 +16,10 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/joakimcarlsson/ai/schema v0.2.0 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/schema v0.2.1 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/joakimcarlsson/ai/tracing v0.2.1 // indirect
-	github.com/joakimcarlsson/ai/types v0.2.0 // indirect
+	github.com/joakimcarlsson/ai/types v0.2.1 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tokens/truncate/go.mod
+++ b/tokens/truncate/go.mod
@@ -1,15 +1,15 @@
 module github.com/joakimcarlsson/ai/tokens/truncate
 
-go 1.25.0
+go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/tokens v0.2.8
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/tokens v0.2.9
 )
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/joakimcarlsson/ai/tool v0.1.3 // indirect
+	github.com/joakimcarlsson/ai/tool v0.1.4 // indirect
 	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tool/go.mod
+++ b/tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/joakimcarlsson/ai/tool
 
-go 1.25.0
+go 1.26.0
 
 require github.com/modelcontextprotocol/go-sdk v1.7.0
 

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,3 +1,3 @@
 module github.com/joakimcarlsson/ai/types
 
-go 1.25.0
+go 1.26.0

--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,16 +3,16 @@ module github.com/joakimcarlsson/ai/voice
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/memory v0.2.10
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.7
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/memory v0.2.11
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/session v0.1.8
 	github.com/joakimcarlsson/ai/stt v0.3.1
-	github.com/joakimcarlsson/ai/tokens v0.2.8
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/tokens v0.2.9
+	github.com/joakimcarlsson/ai/tool v0.1.4
 	github.com/joakimcarlsson/ai/tts v0.3.1
-	github.com/joakimcarlsson/ai/types v0.2.0
+	github.com/joakimcarlsson/ai/types v0.2.1
 	golang.org/x/sync v0.23.0
 )
 


### PR DESCRIPTION
Follow-up to #253/#254. That move raised the `go` directive only on dependency-carrying modules, so 16 were left declaring `go 1.25.0`:

- **Library leaves:** `message`, `types`, `schema`, `tool`, `prompt`, `session`, `tokens`, `tokens/sliding`, `tokens/truncate`
- **Also missed despite getting dep bumps:** `memory/postgres`, `memory/sqlite`
- **Tools:** `cmd/llmstxt`, `cmd/modelsync`
- **Examples:** `model/pricing`, `prompt/embed-templates`, `tokens/truncate`

All now declare `go 1.26.0`, so the repo advertises a single floor.

This does not narrow the usable audience: the effective floor was already 1.26, since nothing here is usable without at least one dependency-carrying module and those all require 1.26. Go 1.25 is also end-of-life now that 1.27 is out, and CI already builds everything on 1.26.8.

Tagging: 13 modules change directly and 28 more are pulled in by the drift closure (they require a bumped module), for 41 patch tags. Examples are not tagged.

Verification: no self-requires, `sync-deps.sh --check` green, all modules and examples build in workspace mode, `tests` vets clean.