### PR TITLE
chore(tests): sync intra-repo requires to release tags

### DIFF
--- a/memory/postgres/tests/go.mod
+++ b/memory/postgres/tests/go.mod
@@ -9,9 +9,9 @@ replace github.com/joakimcarlsson/ai/message => ../../../message
 replace github.com/joakimcarlsson/ai/session => ../../../session
 
 require (
-	github.com/joakimcarlsson/ai/memory/postgres v0.1.8
-	github.com/joakimcarlsson/ai/message v0.5.2
-	github.com/joakimcarlsson/ai/session v0.1.6
+	github.com/joakimcarlsson/ai/memory/postgres v0.1.9
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/session v0.1.8
 	github.com/stretchr/testify v1.12.1
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.44.0

--- a/memory/sqlite/tests/go.mod
+++ b/memory/sqlite/tests/go.mod
@@ -9,8 +9,8 @@ replace github.com/joakimcarlsson/ai/message => ../../../message
 replace github.com/joakimcarlsson/ai/session => ../../../session
 
 require (
-	github.com/joakimcarlsson/ai/memory/sqlite v0.1.9
-	github.com/joakimcarlsson/ai/message v0.5.2
+	github.com/joakimcarlsson/ai/memory/sqlite v0.1.10
+	github.com/joakimcarlsson/ai/message v0.6.1
 	github.com/stretchr/testify v1.12.1
 	modernc.org/sqlite v1.58.0
 )
@@ -18,7 +18,7 @@ require (
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/joakimcarlsson/ai/session v0.1.6 // indirect
+	github.com/joakimcarlsson/ai/session v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,22 +3,22 @@ module github.com/joakimcarlsson/ai/tests
 go 1.26.0
 
 require (
-	github.com/joakimcarlsson/ai/agent v0.5.4
+	github.com/joakimcarlsson/ai/agent v0.5.5
 	github.com/joakimcarlsson/ai/fim v0.3.1
-	github.com/joakimcarlsson/ai/llm v0.6.1
-	github.com/joakimcarlsson/ai/memory v0.2.10
-	github.com/joakimcarlsson/ai/message v0.6.0
-	github.com/joakimcarlsson/ai/prompt v0.1.0
-	github.com/joakimcarlsson/ai/schema v0.2.0
-	github.com/joakimcarlsson/ai/session v0.1.7
+	github.com/joakimcarlsson/ai/llm v0.6.2
+	github.com/joakimcarlsson/ai/memory v0.2.11
+	github.com/joakimcarlsson/ai/message v0.6.1
+	github.com/joakimcarlsson/ai/prompt v0.1.1
+	github.com/joakimcarlsson/ai/schema v0.2.1
+	github.com/joakimcarlsson/ai/session v0.1.8
 	github.com/joakimcarlsson/ai/stt v0.3.1
-	github.com/joakimcarlsson/ai/tokens v0.2.8
-	github.com/joakimcarlsson/ai/tokens/summarize v0.1.11
-	github.com/joakimcarlsson/ai/tool v0.1.3
+	github.com/joakimcarlsson/ai/tokens v0.2.9
+	github.com/joakimcarlsson/ai/tokens/summarize v0.1.12
+	github.com/joakimcarlsson/ai/tool v0.1.4
 	github.com/joakimcarlsson/ai/tracing v0.2.1
 	github.com/joakimcarlsson/ai/tts v0.3.1
-	github.com/joakimcarlsson/ai/types v0.2.0
-	github.com/joakimcarlsson/ai/voice v0.2.11
+	github.com/joakimcarlsson/ai/types v0.2.1
+	github.com/joakimcarlsson/ai/voice v0.2.12
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/log v0.22.0
 	go.opentelemetry.io/otel/sdk v1.46.0


### PR DESCRIPTION
Follow-up to #256: the unpublished test modules sit outside the rewrite closure, so the 41 new tags left 12 of their requires stale. go.mod-only; drift check green and `tests` vets clean in workspace mode.